### PR TITLE
Add operators for LHS comparison with session variables

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -4,7 +4,10 @@
       "Bash(git add *)",
       "Bash(git commit *)",
       "Bash(git push *)",
-      "Bash(gh run *)"
+      "Bash(gh run *)",
+      "Bash(gh pr *)",
+      "Bash(gh api *)",
+      "Bash(git fetch *)"
     ]
   }
 }

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -115,8 +115,8 @@ jobs:
         run: |
           curl -fsS https://packages.microsoft.com/keys/microsoft.asc \
             | sudo gpg --dearmor -o /usr/share/keyrings/microsoft.gpg
-          curl -fsS "https://packages.microsoft.com/config/ubuntu/$(lsb_release -rs)/prod.list" \
-            | sudo sed "s|deb |deb [signed-by=/usr/share/keyrings/microsoft.gpg] |" \
+          ubuntu_release=$(lsb_release -rs)
+          echo "deb [arch=amd64,arm64,armhf signed-by=/usr/share/keyrings/microsoft.gpg] https://packages.microsoft.com/ubuntu/${ubuntu_release}/prod $(lsb_release -cs) main" \
             | sudo tee /etc/apt/sources.list.d/mssql-release.list >/dev/null
           sudo apt-get update
           sudo ACCEPT_EULA=Y apt-get install -y msodbcsql18

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -153,10 +153,13 @@ jobs:
             libpq-dev libssl-dev libkrb5-dev libnuma-dev libpcre3-dev \
             unixodbc-dev libsystemd-dev libreadline-dev
 
+      - name: Read GHC version from .ghcversion
+        run: echo "GHC_VERSION=$(cat .ghcversion)" >> "$GITHUB_ENV"
+
       - name: Set up GHC + cabal
         uses: haskell-actions/setup@v2
         with:
-          ghc-version: '9.10.1'
+          ghc-version: ${{ env.GHC_VERSION }}
           cabal-version: '3.12.1.0'
 
       - name: Repoint cabal.project.local at CI config
@@ -173,19 +176,19 @@ jobs:
           path: |
             ~/.cabal/store
             ~/.cabal/packages
-          key: cabal-${{ runner.os }}-${{ matrix.arch }}-ghc9.10.1-${{ hashFiles('cabal.project.freeze') }}-${{ hashFiles('server/graphql-engine.cabal') }}
+          key: cabal-${{ runner.os }}-${{ matrix.arch }}-ghc${{ env.GHC_VERSION }}-${{ hashFiles('cabal.project.freeze') }}-${{ hashFiles('server/graphql-engine.cabal') }}
           restore-keys: |
-            cabal-${{ runner.os }}-${{ matrix.arch }}-ghc9.10.1-${{ hashFiles('cabal.project.freeze') }}-
-            cabal-${{ runner.os }}-${{ matrix.arch }}-ghc9.10.1-
+            cabal-${{ runner.os }}-${{ matrix.arch }}-ghc${{ env.GHC_VERSION }}-${{ hashFiles('cabal.project.freeze') }}-
+            cabal-${{ runner.os }}-${{ matrix.arch }}-ghc${{ env.GHC_VERSION }}-
 
       - name: Cache dist-newstyle
         uses: actions/cache@v4
         with:
           path: dist-newstyle
-          key: dist-${{ runner.os }}-${{ matrix.arch }}-ghc9.10.1-${{ hashFiles('cabal.project.freeze') }}-${{ hashFiles('server/**/*.hs', 'server/**/*.cabal') }}
+          key: dist-${{ runner.os }}-${{ matrix.arch }}-ghc${{ env.GHC_VERSION }}-${{ hashFiles('cabal.project.freeze') }}-${{ hashFiles('server/**/*.hs', 'server/**/*.cabal') }}
           restore-keys: |
-            dist-${{ runner.os }}-${{ matrix.arch }}-ghc9.10.1-${{ hashFiles('cabal.project.freeze') }}-
-            dist-${{ runner.os }}-${{ matrix.arch }}-ghc9.10.1-
+            dist-${{ runner.os }}-${{ matrix.arch }}-ghc${{ env.GHC_VERSION }}-${{ hashFiles('cabal.project.freeze') }}-
+            dist-${{ runner.os }}-${{ matrix.arch }}-ghc${{ env.GHC_VERSION }}-
 
       - name: Stamp server/CURRENT_VERSION
         # Hasura.Server.Version uses TH at compile time to bake this file's

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -109,18 +109,6 @@ jobs:
             libpq-dev libssl-dev libkrb5-dev libnuma-dev libpcre3-dev \
             unixodbc-dev libsystemd-dev libreadline-dev
 
-      - name: Install MS ODBC driver
-        # Hasura's MSSQL backend may require the Microsoft ODBC driver at link
-        # time. Install it from MS's apt repo.
-        run: |
-          curl -fsS https://packages.microsoft.com/keys/microsoft.asc \
-            | sudo gpg --dearmor -o /usr/share/keyrings/microsoft.gpg
-          ubuntu_release=$(lsb_release -rs)
-          echo "deb [arch=amd64,arm64,armhf signed-by=/usr/share/keyrings/microsoft.gpg] https://packages.microsoft.com/ubuntu/${ubuntu_release}/prod $(lsb_release -cs) main" \
-            | sudo tee /etc/apt/sources.list.d/mssql-release.list >/dev/null
-          sudo apt-get update
-          sudo ACCEPT_EULA=Y apt-get install -y msodbcsql18
-
       - name: Set up GHC + cabal
         uses: haskell-actions/setup@v2
         with:

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -143,6 +143,12 @@ jobs:
             dist-${{ runner.os }}-ghc9.10.1-${{ hashFiles('cabal.project.freeze') }}-
             dist-${{ runner.os }}-ghc9.10.1-
 
+      - name: Stamp server/CURRENT_VERSION
+        # Hasura.Server.Version uses TH at compile time to bake this file's
+        # contents into the binary, with an error message telling you to
+        # populate it. The file is .gitignored, so CI must generate it.
+        run: scripts/get-version.sh > server/CURRENT_VERSION
+
       - name: cabal update
         run: cabal update
 

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -2,7 +2,7 @@ name: Build & publish image
 
 on:
   push:
-    branches: [master]
+    branches: [master, build-ci]
   workflow_dispatch:
 
 env:

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -2,7 +2,7 @@ name: Build & publish image
 
 on:
   push:
-    branches: [build-ci]
+    branches: [master]
   workflow_dispatch:
 
 env:

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -9,15 +9,14 @@ env:
   REGISTRY: ghcr.io
   IMAGE: ${{ github.repository }}
   BASE_IMAGE: ${{ github.repository }}-base
-  PLATFORM: linux/amd64
 
 permissions:
   contents: read
   packages: write
 
 jobs:
-  # Build the runtime base image only when its inputs change.
-  # Other runs reuse the existing tag from the registry.
+  # Build the runtime base image as a multi-arch manifest, only when its inputs
+  # change. Other runs reuse the existing tag from the registry.
   build-base-image:
     runs-on: ubuntu-latest
     outputs:
@@ -44,11 +43,17 @@ jobs:
         env:
           BASE_TAG: ${{ env.REGISTRY }}/${{ env.BASE_IMAGE }}:${{ steps.tag.outputs.value }}
         run: |
+          # docker manifest inspect on a multi-arch index returns the index;
+          # we don't care about its contents, just that it resolves.
           if docker manifest inspect "$BASE_TAG" >/dev/null 2>&1; then
             echo "exists=true" >> "$GITHUB_OUTPUT"
           else
             echo "exists=false" >> "$GITHUB_OUTPUT"
           fi
+
+      - name: Set up QEMU
+        if: steps.probe.outputs.exists == 'false'
+        uses: docker/setup-qemu-action@v3
 
       - name: Set up Docker Buildx
         if: steps.probe.outputs.exists == 'false'
@@ -56,23 +61,26 @@ jobs:
 
       - name: Build & push base image
         if: steps.probe.outputs.exists == 'false'
+        # The base is just apt + a few drivers, ~3 min per arch under qemu.
+        # Worth keeping multi-arch in one step rather than splitting like the
+        # engine image, since the cost is small and rebuilds are infrequent.
         uses: docker/build-push-action@v5
         with:
           context: packaging/graphql-engine-base
           file: packaging/graphql-engine-base/ubuntu.dockerfile
-          platforms: ${{ env.PLATFORM }}
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ env.REGISTRY }}/${{ env.BASE_IMAGE }}:${{ steps.tag.outputs.value }}
           cache-from: type=gha,scope=base-image
           cache-to: type=gha,mode=max,scope=base-image
 
-  build-engine-image:
-    needs: build-base-image
+  # Console assets are arch-independent (just JS/CSS), so we build them once
+  # and feed the result to both engine matrix legs as an artifact.
+  build-console-assets:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
 
-      # ---------- Console assets ----------
       - name: Set up Node
         uses: actions/setup-node@v4
         with:
@@ -99,7 +107,32 @@ jobs:
         working-directory: frontend
         run: node .yarn/releases/yarn-3.2.4.cjs server-build:ce
 
-      # ---------- Engine binary ----------
+      - name: Upload console assets
+        uses: actions/upload-artifact@v4
+        with:
+          name: console-assets
+          path: frontend/dist/apps/server-assets-console-ce
+          retention-days: 1
+
+  # Build the engine binary and the per-arch image natively on each target.
+  # Each leg pushes by digest only (no human tags); merge-manifest stitches
+  # them into a multi-arch manifest below.
+  build-engine-image:
+    needs: [build-base-image, build-console-assets]
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            runner: ubuntu-latest
+            arch: amd64
+          - platform: linux/arm64
+            runner: ubuntu-24.04-arm
+            arch: arm64
+    runs-on: ${{ matrix.runner }}
+    steps:
+      - uses: actions/checkout@v4
+
       - name: Install build dependencies
         # Headers required to compile the Haskell bindings against system
         # libraries. Mirrors the dev-package set in scripts/build-local-image.sh.
@@ -129,19 +162,19 @@ jobs:
           path: |
             ~/.cabal/store
             ~/.cabal/packages
-          key: cabal-${{ runner.os }}-ghc9.10.1-${{ hashFiles('cabal.project.freeze') }}-${{ hashFiles('server/graphql-engine.cabal') }}
+          key: cabal-${{ runner.os }}-${{ matrix.arch }}-ghc9.10.1-${{ hashFiles('cabal.project.freeze') }}-${{ hashFiles('server/graphql-engine.cabal') }}
           restore-keys: |
-            cabal-${{ runner.os }}-ghc9.10.1-${{ hashFiles('cabal.project.freeze') }}-
-            cabal-${{ runner.os }}-ghc9.10.1-
+            cabal-${{ runner.os }}-${{ matrix.arch }}-ghc9.10.1-${{ hashFiles('cabal.project.freeze') }}-
+            cabal-${{ runner.os }}-${{ matrix.arch }}-ghc9.10.1-
 
       - name: Cache dist-newstyle
         uses: actions/cache@v4
         with:
           path: dist-newstyle
-          key: dist-${{ runner.os }}-ghc9.10.1-${{ hashFiles('cabal.project.freeze') }}-${{ hashFiles('server/**/*.hs', 'server/**/*.cabal') }}
+          key: dist-${{ runner.os }}-${{ matrix.arch }}-ghc9.10.1-${{ hashFiles('cabal.project.freeze') }}-${{ hashFiles('server/**/*.hs', 'server/**/*.cabal') }}
           restore-keys: |
-            dist-${{ runner.os }}-ghc9.10.1-${{ hashFiles('cabal.project.freeze') }}-
-            dist-${{ runner.os }}-ghc9.10.1-
+            dist-${{ runner.os }}-${{ matrix.arch }}-ghc9.10.1-${{ hashFiles('cabal.project.freeze') }}-
+            dist-${{ runner.os }}-${{ matrix.arch }}-ghc9.10.1-
 
       - name: Stamp server/CURRENT_VERSION
         # Hasura.Server.Version uses TH at compile time to bake this file's
@@ -155,7 +188,12 @@ jobs:
       - name: Build graphql-engine
         run: cabal build exe:graphql-engine
 
-      # ---------- Assemble rootfs ----------
+      - name: Download console assets
+        uses: actions/download-artifact@v4
+        with:
+          name: console-assets
+          path: frontend/dist/apps/server-assets-console-ce
+
       - name: Stage rootfs
         run: |
           mkdir -p packaging/graphql-engine/rootfs/bin packaging/graphql-engine/rootfs/srv
@@ -165,7 +203,98 @@ jobs:
           ls -la packaging/graphql-engine/rootfs/bin
           du -sh packaging/graphql-engine/rootfs/srv/console-assets
 
-      # ---------- Build & push final image ----------
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build & push by digest
+        id: build
+        # push-by-digest produces an untagged manifest; merge-manifest stitches
+        # the per-arch digests into a multi-arch index with the user-facing tags.
+        uses: docker/build-push-action@v5
+        with:
+          context: packaging/graphql-engine
+          file: packaging/graphql-engine/Dockerfile
+          platforms: ${{ matrix.platform }}
+          build-args: |
+            BASE_IMAGE=${{ env.REGISTRY }}/${{ env.BASE_IMAGE }}:${{ needs.build-base-image.outputs.base-tag }}
+          outputs: type=image,name=${{ env.REGISTRY }}/${{ env.IMAGE }},push-by-digest=true,name-canonical=true,push=true
+          cache-from: type=gha,scope=engine-image-${{ matrix.arch }}
+          cache-to: type=gha,mode=max,scope=engine-image-${{ matrix.arch }}
+
+      - name: Export digest
+        # Matrix-job outputs collapse across legs (last-writer-wins), so we
+        # can't use them to pass per-arch digests. Write to a per-arch file
+        # and upload it as an artifact for merge-manifest to consume.
+        env:
+          DIGEST: ${{ steps.build.outputs.digest }}
+        run: |
+          mkdir -p /tmp/digests
+          # The digest looks like "sha256:abc..."; strip the "sha256:" prefix
+          # so the filename is filesystem-safe and use the digest as a marker.
+          echo -n "${DIGEST}" > "/tmp/digests/${{ matrix.arch }}"
+          echo "Built ${{ matrix.arch }} digest: ${DIGEST}"
+
+      - name: Upload digest artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: digest-${{ matrix.arch }}
+          path: /tmp/digests/${{ matrix.arch }}
+          retention-days: 1
+          if-no-files-found: error
+
+      - name: Smoke test (native arch)
+        env:
+          REF: ${{ env.REGISTRY }}/${{ env.IMAGE }}@${{ steps.build.outputs.digest }}
+        run: |
+          set -e
+          docker network create hasura-test
+          docker run -d --rm --name pg --network hasura-test \
+            -e POSTGRES_PASSWORD=postgres -e POSTGRES_DB=hasura postgres:15
+          for i in $(seq 1 30); do
+            if docker exec pg pg_isready -U postgres >/dev/null 2>&1; then break; fi
+            sleep 1
+          done
+          docker run -d --rm --name engine --network hasura-test -p 18080:8080 \
+            -e HASURA_GRAPHQL_DATABASE_URL=postgres://postgres:postgres@pg:5432/hasura \
+            -e HASURA_GRAPHQL_ENABLE_CONSOLE=true \
+            "$REF"
+          for i in $(seq 1 60); do
+            if curl -fsS http://localhost:18080/healthz >/dev/null; then
+              echo "engine healthy after ${i}s"
+              break
+            fi
+            sleep 1
+          done
+          curl -fsS http://localhost:18080/healthz
+          curl -fsS http://localhost:18080/v1/version
+          curl -fsS -o /dev/null -w 'console index status=%{http_code}\n' http://localhost:18080/console
+          curl -fsS -o /dev/null -w 'assetLoader status=%{http_code}\n' http://localhost:18080/console/assets/versioned/assetLoader.js.gz
+          docker logs engine | tail -20
+          docker rm -f engine pg
+          docker network rm hasura-test
+
+  # Stitch the per-arch digests into a multi-arch manifest with the
+  # user-facing tags.
+  merge-manifest:
+    needs: build-engine-image
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Download digests
+        uses: actions/download-artifact@v4
+        with:
+          path: /tmp/digests
+          pattern: digest-*
+          merge-multiple: true
+
       - name: Log in to GHCR
         uses: docker/login-action@v3
         with:
@@ -183,57 +312,34 @@ jobs:
           REF: ${{ github.ref }}
         run: |
           short=$(git rev-parse --short HEAD)
-          {
-            echo "list<<EOF"
-            echo "${{ env.REGISTRY }}/${{ env.IMAGE }}:$REF_NAME"
-            echo "${{ env.REGISTRY }}/${{ env.IMAGE }}:sha-$short"
-            if [ "$REF" = "refs/heads/master" ]; then
-              echo "${{ env.REGISTRY }}/${{ env.IMAGE }}:latest"
-            fi
-            echo "EOF"
-          } >> "$GITHUB_OUTPUT"
-          echo "short=$short" >> "$GITHUB_OUTPUT"
+          tags=()
+          tags+=("${{ env.REGISTRY }}/${{ env.IMAGE }}:$REF_NAME")
+          tags+=("${{ env.REGISTRY }}/${{ env.IMAGE }}:sha-$short")
+          if [ "$REF" = "refs/heads/master" ]; then
+            tags+=("${{ env.REGISTRY }}/${{ env.IMAGE }}:latest")
+          fi
+          # Render as repeated --tag args for buildx imagetools create.
+          tag_args=""
+          for t in "${tags[@]}"; do
+            tag_args="$tag_args --tag $t"
+          done
+          echo "args=$tag_args" >> "$GITHUB_OUTPUT"
+          echo "primary=${tags[0]}" >> "$GITHUB_OUTPUT"
 
-      - name: Build & push engine image
-        uses: docker/build-push-action@v5
-        with:
-          context: packaging/graphql-engine
-          file: packaging/graphql-engine/Dockerfile
-          platforms: ${{ env.PLATFORM }}
-          push: true
-          build-args: |
-            BASE_IMAGE=${{ env.REGISTRY }}/${{ env.BASE_IMAGE }}:${{ needs.build-base-image.outputs.base-tag }}
-          tags: ${{ steps.tags.outputs.list }}
-          cache-from: type=gha,scope=engine-image
-          cache-to: type=gha,mode=max,scope=engine-image
-
-      - name: Smoke test
+      - name: Create multi-arch manifest
         env:
-          ENGINE_TAG: ${{ env.REGISTRY }}/${{ env.IMAGE }}:sha-${{ steps.tags.outputs.short }}
+          IMAGE_REPO: ${{ env.REGISTRY }}/${{ env.IMAGE }}
         run: |
-          set -e
-          docker network create hasura-test
-          docker run -d --rm --name pg --network hasura-test \
-            -e POSTGRES_PASSWORD=postgres -e POSTGRES_DB=hasura postgres:15
-          for i in $(seq 1 30); do
-            if docker exec pg pg_isready -U postgres >/dev/null 2>&1; then break; fi
-            sleep 1
-          done
-          docker run -d --rm --name engine --network hasura-test -p 18080:8080 \
-            -e HASURA_GRAPHQL_DATABASE_URL=postgres://postgres:postgres@pg:5432/hasura \
-            -e HASURA_GRAPHQL_ENABLE_CONSOLE=true \
-            "$ENGINE_TAG"
-          for i in $(seq 1 60); do
-            if curl -fsS http://localhost:18080/healthz >/dev/null; then
-              echo "engine healthy after ${i}s"
-              break
-            fi
-            sleep 1
-          done
-          curl -fsS http://localhost:18080/healthz
-          curl -fsS http://localhost:18080/v1/version
-          curl -fsS -o /dev/null -w 'console index status=%{http_code}\n' http://localhost:18080/console
-          curl -fsS -o /dev/null -w 'assetLoader status=%{http_code}\n' http://localhost:18080/console/assets/versioned/assetLoader.js.gz
-          docker logs engine | tail -20
-          docker rm -f engine pg
-          docker network rm hasura-test
+          AMD64_DIGEST=$(cat /tmp/digests/amd64)
+          ARM64_DIGEST=$(cat /tmp/digests/arm64)
+          echo "amd64: $AMD64_DIGEST"
+          echo "arm64: $ARM64_DIGEST"
+          docker buildx imagetools create \
+            ${{ steps.tags.outputs.args }} \
+            "${IMAGE_REPO}@${AMD64_DIGEST}" \
+            "${IMAGE_REPO}@${ARM64_DIGEST}"
+
+      - name: Inspect resulting manifest
+        env:
+          PRIMARY: ${{ steps.tags.outputs.primary }}
+        run: docker buildx imagetools inspect "$PRIMARY"

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -38,17 +38,28 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Check whether base image already exists
+      - name: Check whether base image already exists for both platforms
         id: probe
         env:
           BASE_TAG: ${{ env.REGISTRY }}/${{ env.BASE_IMAGE }}:${{ steps.tag.outputs.value }}
+        # Skip rebuild only if the existing manifest covers BOTH amd64 and
+        # arm64. A pre-existing single-arch manifest (e.g. from an older
+        # workflow) would otherwise be re-used and the engine build for the
+        # missing arch would fail with "no match for platform in manifest".
         run: |
-          # docker manifest inspect on a multi-arch index returns the index;
-          # we don't care about its contents, just that it resolves.
-          if docker manifest inspect "$BASE_TAG" >/dev/null 2>&1; then
+          if ! manifest=$(docker manifest inspect "$BASE_TAG" 2>/dev/null); then
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+            echo "reason: tag does not exist"
+            exit 0
+          fi
+          have_amd64=$(echo "$manifest" | jq -r '[.manifests[]?.platform.architecture] | any(. == "amd64")')
+          have_arm64=$(echo "$manifest" | jq -r '[.manifests[]?.platform.architecture] | any(. == "arm64")')
+          if [ "$have_amd64" = "true" ] && [ "$have_arm64" = "true" ]; then
             echo "exists=true" >> "$GITHUB_OUTPUT"
+            echo "reason: tag has both amd64 and arm64"
           else
             echo "exists=false" >> "$GITHUB_OUTPUT"
+            echo "reason: tag missing platforms (amd64=$have_amd64, arm64=$have_arm64)"
           fi
 
       - name: Set up QEMU

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -100,6 +100,27 @@ jobs:
         run: node .yarn/releases/yarn-3.2.4.cjs server-build:ce
 
       # ---------- Engine binary ----------
+      - name: Install build dependencies
+        # Headers required to compile the Haskell bindings against system
+        # libraries. Mirrors the dev-package set in scripts/build-local-image.sh.
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            libpq-dev libssl-dev libkrb5-dev libnuma-dev libpcre3-dev \
+            unixodbc-dev libsystemd-dev libreadline-dev
+
+      - name: Install MS ODBC driver
+        # Hasura's MSSQL backend may require the Microsoft ODBC driver at link
+        # time. Install it from MS's apt repo.
+        run: |
+          curl -fsS https://packages.microsoft.com/keys/microsoft.asc \
+            | sudo gpg --dearmor -o /usr/share/keyrings/microsoft.gpg
+          curl -fsS "https://packages.microsoft.com/config/ubuntu/$(lsb_release -rs)/prod.list" \
+            | sudo sed "s|deb |deb [signed-by=/usr/share/keyrings/microsoft.gpg] |" \
+            | sudo tee /etc/apt/sources.list.d/mssql-release.list >/dev/null
+          sudo apt-get update
+          sudo ACCEPT_EULA=Y apt-get install -y msodbcsql18
+
       - name: Set up GHC + cabal
         uses: haskell-actions/setup@v2
         with:

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -326,8 +326,24 @@ jobs:
           REF: ${{ github.ref }}
         run: |
           short=$(git rev-parse --short HEAD)
+          # Sanitize the branch name into a valid OCI tag:
+          #   1. lowercase
+          #   2. replace anything outside [a-z0-9._-] with '-'
+          #   3. collapse repeated '-'
+          #   4. strip leading/trailing '.' and '-'
+          #   5. truncate to 128 chars
+          # Same rule docker/metadata-action applies. Avoids "invalid reference
+          # format" failures when branches contain '/' or other characters.
+          ref_tag=$(printf '%s' "$REF_NAME" \
+            | tr '[:upper:]' '[:lower:]' \
+            | sed -E -e 's/[^a-z0-9._-]+/-/g' -e 's/-+/-/g' -e 's/^[.-]+//' -e 's/[.-]+$//' \
+            | cut -c1-128)
+          # Defensive: if sanitization stripped everything, fall back to the SHA.
+          if [ -z "$ref_tag" ]; then
+            ref_tag="sha-$short"
+          fi
           tags=()
-          tags+=("${{ env.REGISTRY }}/${{ env.IMAGE }}:$REF_NAME")
+          tags+=("${{ env.REGISTRY }}/${{ env.IMAGE }}:$ref_tag")
           tags+=("${{ env.REGISTRY }}/${{ env.IMAGE }}:sha-$short")
           if [ "$REF" = "refs/heads/master" ]; then
             tags+=("${{ env.REGISTRY }}/${{ env.IMAGE }}:latest")

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -2,21 +2,22 @@ name: Build & publish image
 
 on:
   push:
-    branches: [master, build-ci]
+    branches: [build-ci]
   workflow_dispatch:
 
 env:
   REGISTRY: ghcr.io
   IMAGE: ${{ github.repository }}
   BASE_IMAGE: ${{ github.repository }}-base
+  PLATFORM: linux/amd64
 
 permissions:
   contents: read
   packages: write
 
 jobs:
-  # Build the runtime base image as a multi-arch manifest, only when its inputs
-  # change. Other runs reuse the existing tag from the registry.
+  # Build the runtime base image only when its inputs change.
+  # Other runs reuse the existing tag from the registry.
   build-base-image:
     runs-on: ubuntu-latest
     outputs:
@@ -38,33 +39,16 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Check whether base image already exists for both platforms
+      - name: Check whether base image already exists
         id: probe
         env:
           BASE_TAG: ${{ env.REGISTRY }}/${{ env.BASE_IMAGE }}:${{ steps.tag.outputs.value }}
-        # Skip rebuild only if the existing manifest covers BOTH amd64 and
-        # arm64. A pre-existing single-arch manifest (e.g. from an older
-        # workflow) would otherwise be re-used and the engine build for the
-        # missing arch would fail with "no match for platform in manifest".
         run: |
-          if ! manifest=$(docker manifest inspect "$BASE_TAG" 2>/dev/null); then
-            echo "exists=false" >> "$GITHUB_OUTPUT"
-            echo "reason: tag does not exist"
-            exit 0
-          fi
-          have_amd64=$(echo "$manifest" | jq -r '[.manifests[]?.platform.architecture] | any(. == "amd64")')
-          have_arm64=$(echo "$manifest" | jq -r '[.manifests[]?.platform.architecture] | any(. == "arm64")')
-          if [ "$have_amd64" = "true" ] && [ "$have_arm64" = "true" ]; then
+          if docker manifest inspect "$BASE_TAG" >/dev/null 2>&1; then
             echo "exists=true" >> "$GITHUB_OUTPUT"
-            echo "reason: tag has both amd64 and arm64"
           else
             echo "exists=false" >> "$GITHUB_OUTPUT"
-            echo "reason: tag missing platforms (amd64=$have_amd64, arm64=$have_arm64)"
           fi
-
-      - name: Set up QEMU
-        if: steps.probe.outputs.exists == 'false'
-        uses: docker/setup-qemu-action@v3
 
       - name: Set up Docker Buildx
         if: steps.probe.outputs.exists == 'false'
@@ -72,26 +56,23 @@ jobs:
 
       - name: Build & push base image
         if: steps.probe.outputs.exists == 'false'
-        # The base is just apt + a few drivers, ~3 min per arch under qemu.
-        # Worth keeping multi-arch in one step rather than splitting like the
-        # engine image, since the cost is small and rebuilds are infrequent.
         uses: docker/build-push-action@v5
         with:
           context: packaging/graphql-engine-base
           file: packaging/graphql-engine-base/ubuntu.dockerfile
-          platforms: linux/amd64,linux/arm64
+          platforms: ${{ env.PLATFORM }}
           push: true
           tags: ${{ env.REGISTRY }}/${{ env.BASE_IMAGE }}:${{ steps.tag.outputs.value }}
           cache-from: type=gha,scope=base-image
           cache-to: type=gha,mode=max,scope=base-image
 
-  # Console assets are arch-independent (just JS/CSS), so we build them once
-  # and feed the result to both engine matrix legs as an artifact.
-  build-console-assets:
+  build-engine-image:
+    needs: build-base-image
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
 
+      # ---------- Console assets ----------
       - name: Set up Node
         uses: actions/setup-node@v4
         with:
@@ -118,48 +99,11 @@ jobs:
         working-directory: frontend
         run: node .yarn/releases/yarn-3.2.4.cjs server-build:ce
 
-      - name: Upload console assets
-        uses: actions/upload-artifact@v4
-        with:
-          name: console-assets
-          path: frontend/dist/apps/server-assets-console-ce
-          retention-days: 1
-
-  # Build the engine binary and the per-arch image natively on each target.
-  # Each leg pushes by digest only (no human tags); merge-manifest stitches
-  # them into a multi-arch manifest below.
-  build-engine-image:
-    needs: [build-base-image, build-console-assets]
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - platform: linux/amd64
-            runner: ubuntu-latest
-            arch: amd64
-          - platform: linux/arm64
-            runner: ubuntu-24.04-arm
-            arch: arm64
-    runs-on: ${{ matrix.runner }}
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Install build dependencies
-        # Headers required to compile the Haskell bindings against system
-        # libraries. Mirrors the dev-package set in scripts/build-local-image.sh.
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y \
-            libpq-dev libssl-dev libkrb5-dev libnuma-dev libpcre3-dev \
-            unixodbc-dev libsystemd-dev libreadline-dev
-
-      - name: Read GHC version from .ghcversion
-        run: echo "GHC_VERSION=$(cat .ghcversion)" >> "$GITHUB_ENV"
-
+      # ---------- Engine binary ----------
       - name: Set up GHC + cabal
         uses: haskell-actions/setup@v2
         with:
-          ghc-version: ${{ env.GHC_VERSION }}
+          ghc-version: '9.10.1'
           cabal-version: '3.12.1.0'
 
       - name: Repoint cabal.project.local at CI config
@@ -176,25 +120,19 @@ jobs:
           path: |
             ~/.cabal/store
             ~/.cabal/packages
-          key: cabal-${{ runner.os }}-${{ matrix.arch }}-ghc${{ env.GHC_VERSION }}-${{ hashFiles('cabal.project.freeze') }}-${{ hashFiles('server/graphql-engine.cabal') }}
+          key: cabal-${{ runner.os }}-ghc9.10.1-${{ hashFiles('cabal.project.freeze') }}-${{ hashFiles('server/graphql-engine.cabal') }}
           restore-keys: |
-            cabal-${{ runner.os }}-${{ matrix.arch }}-ghc${{ env.GHC_VERSION }}-${{ hashFiles('cabal.project.freeze') }}-
-            cabal-${{ runner.os }}-${{ matrix.arch }}-ghc${{ env.GHC_VERSION }}-
+            cabal-${{ runner.os }}-ghc9.10.1-${{ hashFiles('cabal.project.freeze') }}-
+            cabal-${{ runner.os }}-ghc9.10.1-
 
       - name: Cache dist-newstyle
         uses: actions/cache@v4
         with:
           path: dist-newstyle
-          key: dist-${{ runner.os }}-${{ matrix.arch }}-ghc${{ env.GHC_VERSION }}-${{ hashFiles('cabal.project.freeze') }}-${{ hashFiles('server/**/*.hs', 'server/**/*.cabal') }}
+          key: dist-${{ runner.os }}-ghc9.10.1-${{ hashFiles('cabal.project.freeze') }}-${{ hashFiles('server/**/*.hs', 'server/**/*.cabal') }}
           restore-keys: |
-            dist-${{ runner.os }}-${{ matrix.arch }}-ghc${{ env.GHC_VERSION }}-${{ hashFiles('cabal.project.freeze') }}-
-            dist-${{ runner.os }}-${{ matrix.arch }}-ghc${{ env.GHC_VERSION }}-
-
-      - name: Stamp server/CURRENT_VERSION
-        # Hasura.Server.Version uses TH at compile time to bake this file's
-        # contents into the binary, with an error message telling you to
-        # populate it. The file is .gitignored, so CI must generate it.
-        run: scripts/get-version.sh > server/CURRENT_VERSION
+            dist-${{ runner.os }}-ghc9.10.1-${{ hashFiles('cabal.project.freeze') }}-
+            dist-${{ runner.os }}-ghc9.10.1-
 
       - name: cabal update
         run: cabal update
@@ -202,12 +140,7 @@ jobs:
       - name: Build graphql-engine
         run: cabal build exe:graphql-engine
 
-      - name: Download console assets
-        uses: actions/download-artifact@v4
-        with:
-          name: console-assets
-          path: frontend/dist/apps/server-assets-console-ce
-
+      # ---------- Assemble rootfs ----------
       - name: Stage rootfs
         run: |
           mkdir -p packaging/graphql-engine/rootfs/bin packaging/graphql-engine/rootfs/srv
@@ -217,98 +150,7 @@ jobs:
           ls -la packaging/graphql-engine/rootfs/bin
           du -sh packaging/graphql-engine/rootfs/srv/console-assets
 
-      - name: Log in to GHCR
-        uses: docker/login-action@v3
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Build & push by digest
-        id: build
-        # push-by-digest produces an untagged manifest; merge-manifest stitches
-        # the per-arch digests into a multi-arch index with the user-facing tags.
-        uses: docker/build-push-action@v5
-        with:
-          context: packaging/graphql-engine
-          file: packaging/graphql-engine/Dockerfile
-          platforms: ${{ matrix.platform }}
-          build-args: |
-            BASE_IMAGE=${{ env.REGISTRY }}/${{ env.BASE_IMAGE }}:${{ needs.build-base-image.outputs.base-tag }}
-          outputs: type=image,name=${{ env.REGISTRY }}/${{ env.IMAGE }},push-by-digest=true,name-canonical=true,push=true
-          cache-from: type=gha,scope=engine-image-${{ matrix.arch }}
-          cache-to: type=gha,mode=max,scope=engine-image-${{ matrix.arch }}
-
-      - name: Export digest
-        # Matrix-job outputs collapse across legs (last-writer-wins), so we
-        # can't use them to pass per-arch digests. Write to a per-arch file
-        # and upload it as an artifact for merge-manifest to consume.
-        env:
-          DIGEST: ${{ steps.build.outputs.digest }}
-        run: |
-          mkdir -p /tmp/digests
-          # The digest looks like "sha256:abc..."; strip the "sha256:" prefix
-          # so the filename is filesystem-safe and use the digest as a marker.
-          echo -n "${DIGEST}" > "/tmp/digests/${{ matrix.arch }}"
-          echo "Built ${{ matrix.arch }} digest: ${DIGEST}"
-
-      - name: Upload digest artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: digest-${{ matrix.arch }}
-          path: /tmp/digests/${{ matrix.arch }}
-          retention-days: 1
-          if-no-files-found: error
-
-      - name: Smoke test (native arch)
-        env:
-          REF: ${{ env.REGISTRY }}/${{ env.IMAGE }}@${{ steps.build.outputs.digest }}
-        run: |
-          set -e
-          docker network create hasura-test
-          docker run -d --rm --name pg --network hasura-test \
-            -e POSTGRES_PASSWORD=postgres -e POSTGRES_DB=hasura postgres:15
-          for i in $(seq 1 30); do
-            if docker exec pg pg_isready -U postgres >/dev/null 2>&1; then break; fi
-            sleep 1
-          done
-          docker run -d --rm --name engine --network hasura-test -p 18080:8080 \
-            -e HASURA_GRAPHQL_DATABASE_URL=postgres://postgres:postgres@pg:5432/hasura \
-            -e HASURA_GRAPHQL_ENABLE_CONSOLE=true \
-            "$REF"
-          for i in $(seq 1 60); do
-            if curl -fsS http://localhost:18080/healthz >/dev/null; then
-              echo "engine healthy after ${i}s"
-              break
-            fi
-            sleep 1
-          done
-          curl -fsS http://localhost:18080/healthz
-          curl -fsS http://localhost:18080/v1/version
-          curl -fsS -o /dev/null -w 'console index status=%{http_code}\n' http://localhost:18080/console
-          curl -fsS -o /dev/null -w 'assetLoader status=%{http_code}\n' http://localhost:18080/console/assets/versioned/assetLoader.js.gz
-          docker logs engine | tail -20
-          docker rm -f engine pg
-          docker network rm hasura-test
-
-  # Stitch the per-arch digests into a multi-arch manifest with the
-  # user-facing tags.
-  merge-manifest:
-    needs: build-engine-image
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Download digests
-        uses: actions/download-artifact@v4
-        with:
-          path: /tmp/digests
-          pattern: digest-*
-          merge-multiple: true
-
+      # ---------- Build & push final image ----------
       - name: Log in to GHCR
         uses: docker/login-action@v3
         with:
@@ -326,50 +168,57 @@ jobs:
           REF: ${{ github.ref }}
         run: |
           short=$(git rev-parse --short HEAD)
-          # Sanitize the branch name into a valid OCI tag:
-          #   1. lowercase
-          #   2. replace anything outside [a-z0-9._-] with '-'
-          #   3. collapse repeated '-'
-          #   4. strip leading/trailing '.' and '-'
-          #   5. truncate to 128 chars
-          # Same rule docker/metadata-action applies. Avoids "invalid reference
-          # format" failures when branches contain '/' or other characters.
-          ref_tag=$(printf '%s' "$REF_NAME" \
-            | tr '[:upper:]' '[:lower:]' \
-            | sed -E -e 's/[^a-z0-9._-]+/-/g' -e 's/-+/-/g' -e 's/^[.-]+//' -e 's/[.-]+$//' \
-            | cut -c1-128)
-          # Defensive: if sanitization stripped everything, fall back to the SHA.
-          if [ -z "$ref_tag" ]; then
-            ref_tag="sha-$short"
-          fi
-          tags=()
-          tags+=("${{ env.REGISTRY }}/${{ env.IMAGE }}:$ref_tag")
-          tags+=("${{ env.REGISTRY }}/${{ env.IMAGE }}:sha-$short")
-          if [ "$REF" = "refs/heads/master" ]; then
-            tags+=("${{ env.REGISTRY }}/${{ env.IMAGE }}:latest")
-          fi
-          # Render as repeated --tag args for buildx imagetools create.
-          tag_args=""
-          for t in "${tags[@]}"; do
-            tag_args="$tag_args --tag $t"
-          done
-          echo "args=$tag_args" >> "$GITHUB_OUTPUT"
-          echo "primary=${tags[0]}" >> "$GITHUB_OUTPUT"
+          {
+            echo "list<<EOF"
+            echo "${{ env.REGISTRY }}/${{ env.IMAGE }}:$REF_NAME"
+            echo "${{ env.REGISTRY }}/${{ env.IMAGE }}:sha-$short"
+            if [ "$REF" = "refs/heads/master" ]; then
+              echo "${{ env.REGISTRY }}/${{ env.IMAGE }}:latest"
+            fi
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+          echo "short=$short" >> "$GITHUB_OUTPUT"
 
-      - name: Create multi-arch manifest
+      - name: Build & push engine image
+        uses: docker/build-push-action@v5
+        with:
+          context: packaging/graphql-engine
+          file: packaging/graphql-engine/Dockerfile
+          platforms: ${{ env.PLATFORM }}
+          push: true
+          build-args: |
+            BASE_IMAGE=${{ env.REGISTRY }}/${{ env.BASE_IMAGE }}:${{ needs.build-base-image.outputs.base-tag }}
+          tags: ${{ steps.tags.outputs.list }}
+          cache-from: type=gha,scope=engine-image
+          cache-to: type=gha,mode=max,scope=engine-image
+
+      - name: Smoke test
         env:
-          IMAGE_REPO: ${{ env.REGISTRY }}/${{ env.IMAGE }}
+          ENGINE_TAG: ${{ env.REGISTRY }}/${{ env.IMAGE }}:sha-${{ steps.tags.outputs.short }}
         run: |
-          AMD64_DIGEST=$(cat /tmp/digests/amd64)
-          ARM64_DIGEST=$(cat /tmp/digests/arm64)
-          echo "amd64: $AMD64_DIGEST"
-          echo "arm64: $ARM64_DIGEST"
-          docker buildx imagetools create \
-            ${{ steps.tags.outputs.args }} \
-            "${IMAGE_REPO}@${AMD64_DIGEST}" \
-            "${IMAGE_REPO}@${ARM64_DIGEST}"
-
-      - name: Inspect resulting manifest
-        env:
-          PRIMARY: ${{ steps.tags.outputs.primary }}
-        run: docker buildx imagetools inspect "$PRIMARY"
+          set -e
+          docker network create hasura-test
+          docker run -d --rm --name pg --network hasura-test \
+            -e POSTGRES_PASSWORD=postgres -e POSTGRES_DB=hasura postgres:15
+          for i in $(seq 1 30); do
+            if docker exec pg pg_isready -U postgres >/dev/null 2>&1; then break; fi
+            sleep 1
+          done
+          docker run -d --rm --name engine --network hasura-test -p 18080:8080 \
+            -e HASURA_GRAPHQL_DATABASE_URL=postgres://postgres:postgres@pg:5432/hasura \
+            -e HASURA_GRAPHQL_ENABLE_CONSOLE=true \
+            "$ENGINE_TAG"
+          for i in $(seq 1 60); do
+            if curl -fsS http://localhost:18080/healthz >/dev/null; then
+              echo "engine healthy after ${i}s"
+              break
+            fi
+            sleep 1
+          done
+          curl -fsS http://localhost:18080/healthz
+          curl -fsS http://localhost:18080/v1/version
+          curl -fsS -o /dev/null -w 'console index status=%{http_code}\n' http://localhost:18080/console
+          curl -fsS -o /dev/null -w 'assetLoader status=%{http_code}\n' http://localhost:18080/console/assets/versioned/assetLoader.js.gz
+          docker logs engine | tail -20
+          docker rm -f engine pg
+          docker network rm hasura-test

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -2,7 +2,7 @@ name: Build & publish image
 
 on:
   push:
-    branches: [master, build-ci]
+    branches: [master, build-ci, session-var-operators]
   workflow_dispatch:
 
 env:

--- a/frontend/libs/console/legacy-ce/src/lib/components/Services/Data/TablePermissions/PermissionBuilder/PermissionBuilder.tsx
+++ b/frontend/libs/console/legacy-ce/src/lib/components/Services/Data/TablePermissions/PermissionBuilder/PermissionBuilder.tsx
@@ -28,6 +28,7 @@ import {
   boolOperators,
   deprecatedColumnOperators,
   existOperators,
+  sessionVarOperators,
   getOperatorInputType,
   getPermissionOperators,
   getRootType,
@@ -36,6 +37,7 @@ import {
   isBoolOperator,
   isColumnOperator,
   isExistOperator,
+  isSessionVarOperator,
   TABLE_KEY,
   WHERE_KEY,
 } from './utils';
@@ -134,6 +136,8 @@ class PermissionBuilder extends React.Component<PermissionBuilderProps> {
           existTableDef as QualifiedTable,
           JSON.stringify(existWhere)
         );
+      } else if (isSessionVarOperator(operator)) {
+        // no missing schemas for session variable operators
       } else if (isColumnOperator(operator)) {
         // no missing schemas
       } else {
@@ -321,6 +325,37 @@ class PermissionBuilder extends React.Component<PermissionBuilderProps> {
         return filter;
       };
 
+      const getSessionVarOperatorFilter = (
+        operator: string,
+        opValue: any,
+        opConditions: Record<string, any>,
+        opPrefix: string,
+        isLast: boolean
+      ) => {
+        const filter: Record<string, any> = {
+          [operator]: opConditions,
+        };
+
+        if (isLast) {
+          filter[operator] = {
+            var: '',
+            value: '',
+          };
+        } else if (opPrefix === 'var') {
+          filter[operator] = {
+            var: opValue,
+            value: opConditions?.value || '',
+          };
+        } else if (opPrefix === 'value') {
+          filter[operator] = {
+            var: opConditions?.var || '',
+            value: opValue,
+          };
+        }
+
+        return filter;
+      };
+
       const getColumnFilter = (
         operator: string,
         opValue: string,
@@ -383,6 +418,14 @@ class PermissionBuilder extends React.Component<PermissionBuilderProps> {
         boolExp = getColumnOperatorFilter(operator, value);
       } else if (isExistOperator(operator)) {
         boolExp = getExistsOperatorFilter(
+          operator,
+          value,
+          opConditions,
+          newPrefix,
+          isLast
+        );
+      } else if (isSessionVarOperator(operator)) {
+        boolExp = getSessionVarOperatorFilter(
           operator,
           value,
           opConditions,
@@ -966,6 +1009,44 @@ class PermissionBuilder extends React.Component<PermissionBuilderProps> {
       return <QueryBuilderJson element={tableExp} />;
     };
 
+    const renderSessionVarExp = (
+      dispatchFunc: (arg0: { prefix: string; value: any }) => void,
+      operation: string,
+      expression: Record<string, any>,
+      prefix: string
+    ) => {
+      const dispatchVarInput = (val: string) => {
+        dispatchFunc({ prefix: addToPrefix(prefix, 'var'), value: val });
+      };
+
+      const dispatchValueInput = (val: string) => {
+        dispatchFunc({ prefix: addToPrefix(prefix, 'value'), value: val });
+      };
+
+      const sessionVar = expression.var || '';
+      const sessionValue = expression.value || '';
+
+      const varInput = renderInput(dispatchVarInput, sessionVar);
+      const valueInput = renderInput(dispatchValueInput, sessionValue);
+
+      const sessionVarArgsJsonObject = {
+        var: varInput,
+        value: valueInput,
+      };
+
+      const unselectedElements = [];
+      if (!sessionVar) {
+        unselectedElements.push('value');
+      }
+
+      return (
+        <QueryBuilderJson
+          element={sessionVarArgsJsonObject}
+          unselectedElements={unselectedElements}
+        />
+      );
+    };
+
     const renderExistsExp = (
       dispatchFunc: (arg0: { prefix: string; value: any }) => void,
       operation: string,
@@ -1108,6 +1189,7 @@ class PermissionBuilder extends React.Component<PermissionBuilderProps> {
       const newOperatorOptions = [
         { optGroupTitle: 'bool operators', options: boolOperators },
         { optGroupTitle: 'exist operators', options: existOperators },
+        { optGroupTitle: 'session variable operators', options: sessionVarOperators },
         { optGroupTitle: 'columns', options: tableColumnNames },
         { optGroupTitle: 'relationships', options: tableRelationshipNames },
         { optGroupTitle: 'computed fields', options: computedFieldsOptions },
@@ -1150,6 +1232,13 @@ class PermissionBuilder extends React.Component<PermissionBuilderProps> {
             tableDef,
             tableSchemas,
             schemaList,
+            newPrefix
+          );
+        } else if (isSessionVarOperator(operation)) {
+          boolExpValue = renderSessionVarExp(
+            dispatchFunc,
+            operation,
+            expression[operation],
             newPrefix
           );
         } else {

--- a/frontend/libs/console/legacy-ce/src/lib/components/Services/Data/TablePermissions/PermissionBuilder/utils.js
+++ b/frontend/libs/console/legacy-ce/src/lib/components/Services/Data/TablePermissions/PermissionBuilder/utils.js
@@ -32,6 +32,25 @@ export const boolOperatorsInfo = {
   },
 };
 
+export const sessionVarOperatorsInfo = {
+  _seq: {
+    type: 'sessionVar',
+    inputStructure: 'object',
+  },
+  _sne: {
+    type: 'sessionVar',
+    inputStructure: 'object',
+  },
+  _scontains: {
+    type: 'sessionVar',
+    inputStructure: 'object',
+  },
+  _sin: {
+    type: 'sessionVar',
+    inputStructure: 'object',
+  },
+};
+
 export const columnOperatorsInfo = {
   _eq: {
     type: 'comparision',
@@ -236,10 +255,13 @@ export const boolOperators = Object.keys(boolOperatorsInfo);
 
 const columnOperators = Object.keys(columnOperatorsInfo);
 
+export const sessionVarOperators = Object.keys(sessionVarOperatorsInfo);
+
 export const existOperators = ['_exists'];
 
 export const allOperators = boolOperators
   .concat(columnOperators)
+  .concat(sessionVarOperators)
   .concat(existOperators);
 
 export const TABLE_KEY = '_table';
@@ -255,6 +277,10 @@ export const isBoolOperator = operator => {
 
 export const isExistOperator = operator => {
   return existOperators.includes(operator);
+};
+
+export const isSessionVarOperator = operator => {
+  return sessionVarOperators.includes(operator);
 };
 
 export const isArrayBoolOperator = operator => {

--- a/frontend/libs/console/legacy-ce/src/lib/components/Services/Data/TablePermissions/PermissionBuilder/utils.test.js
+++ b/frontend/libs/console/legacy-ce/src/lib/components/Services/Data/TablePermissions/PermissionBuilder/utils.test.js
@@ -1,0 +1,160 @@
+import {
+  sessionVarOperatorsInfo,
+  sessionVarOperators,
+  isSessionVarOperator,
+  allOperators,
+  boolOperators,
+  existOperators,
+} from './utils';
+
+describe('PermissionBuilder Utils - Session Variables', () => {
+  describe('sessionVarOperatorsInfo', () => {
+    it('defines all session variable operators with correct structure', () => {
+      expect(sessionVarOperatorsInfo).toEqual({
+        _seq: {
+          type: 'sessionVar',
+          inputStructure: 'object',
+        },
+        _sne: {
+          type: 'sessionVar',
+          inputStructure: 'object',
+        },
+        _scontains: {
+          type: 'sessionVar',
+          inputStructure: 'object',
+        },
+        _sin: {
+          type: 'sessionVar',
+          inputStructure: 'object',
+        },
+      });
+    });
+
+    it('has consistent structure with other operator info objects', () => {
+      Object.values(sessionVarOperatorsInfo).forEach(operatorInfo => {
+        expect(operatorInfo).toHaveProperty('type');
+        expect(operatorInfo).toHaveProperty('inputStructure');
+        expect(operatorInfo.type).toBe('sessionVar');
+        expect(operatorInfo.inputStructure).toBe('object');
+      });
+    });
+  });
+
+  describe('sessionVarOperators', () => {
+    it('exports all session variable operator names', () => {
+      expect(sessionVarOperators).toEqual(['_seq', '_sne', '_scontains', '_sin']);
+    });
+
+    it('matches keys from sessionVarOperatorsInfo', () => {
+      const infoKeys = Object.keys(sessionVarOperatorsInfo);
+      expect(sessionVarOperators.sort()).toEqual(infoKeys.sort());
+    });
+  });
+
+  describe('isSessionVarOperator', () => {
+    it('returns true for valid session variable operators', () => {
+      expect(isSessionVarOperator('_seq')).toBe(true);
+      expect(isSessionVarOperator('_sne')).toBe(true);
+      expect(isSessionVarOperator('_scontains')).toBe(true);
+      expect(isSessionVarOperator('_sin')).toBe(true);
+    });
+
+    it('returns false for non-session variable operators', () => {
+      expect(isSessionVarOperator('_eq')).toBe(false);
+      expect(isSessionVarOperator('_and')).toBe(false);
+      expect(isSessionVarOperator('_exists')).toBe(false);
+      expect(isSessionVarOperator('_unknown')).toBe(false);
+      expect(isSessionVarOperator('')).toBe(false);
+      expect(isSessionVarOperator(null)).toBe(false);
+      expect(isSessionVarOperator(undefined)).toBe(false);
+    });
+  });
+
+  describe('allOperators integration', () => {
+    it('includes session variable operators in allOperators', () => {
+      sessionVarOperators.forEach(op => {
+        expect(allOperators).toContain(op);
+      });
+    });
+
+    it('maintains distinct operator lists', () => {
+      // No overlap between different operator types
+      sessionVarOperators.forEach(sessionOp => {
+        expect(boolOperators).not.toContain(sessionOp);
+        expect(existOperators).not.toContain(sessionOp);
+      });
+    });
+
+    it('allOperators contains all operator types', () => {
+      const expectedLength = 
+        boolOperators.length + 
+        sessionVarOperators.length + 
+        existOperators.length +
+        Object.keys(require('./utils').columnOperatorsInfo).length;
+      
+      expect(allOperators.length).toBe(expectedLength);
+    });
+  });
+
+  describe('Operator naming conventions', () => {
+    it('follows _s* naming pattern for session variable operators', () => {
+      sessionVarOperators.forEach(op => {
+        expect(op).toMatch(/^_s\w+$/);
+      });
+    });
+
+    it('has unique operator names', () => {
+      const uniqueOperators = new Set(sessionVarOperators);
+      expect(uniqueOperators.size).toBe(sessionVarOperators.length);
+    });
+  });
+
+  describe('TypeScript compatibility', () => {
+    it('operators can be used as object keys', () => {
+      const testObj = {};
+      sessionVarOperators.forEach(op => {
+        testObj[op] = true;
+      });
+      
+      expect(Object.keys(testObj)).toEqual(sessionVarOperators);
+    });
+
+    it('operator info can be accessed dynamically', () => {
+      sessionVarOperators.forEach(op => {
+        const info = sessionVarOperatorsInfo[op];
+        expect(info).toBeDefined();
+        expect(info.type).toBe('sessionVar');
+      });
+    });
+  });
+
+  describe('Integration with existing operator functions', () => {
+    it('isSessionVarOperator is consistent with other operator type functions', () => {
+      const { isBoolOperator, isExistOperator, isColumnOperator } = require('./utils');
+      
+      // Session var operators should not be identified as other types
+      sessionVarOperators.forEach(op => {
+        expect(isBoolOperator(op)).toBe(false);
+        expect(isExistOperator(op)).toBe(false);
+        expect(isColumnOperator(op)).toBe(false);
+        expect(isSessionVarOperator(op)).toBe(true);
+      });
+    });
+
+    it('other operators should not be identified as session var operators', () => {
+      const { isBoolOperator, isExistOperator } = require('./utils');
+      
+      boolOperators.forEach(op => {
+        if (isBoolOperator(op)) {
+          expect(isSessionVarOperator(op)).toBe(false);
+        }
+      });
+
+      existOperators.forEach(op => {
+        if (isExistOperator(op)) {
+          expect(isSessionVarOperator(op)).toBe(false);
+        }
+      });
+    });
+  });
+});

--- a/frontend/libs/console/legacy-ce/src/lib/features/Permissions/PermissionsForm/components/RowPermissionsBuilder/components/EntryType.tsx
+++ b/frontend/libs/console/legacy-ce/src/lib/features/Permissions/PermissionsForm/components/RowPermissionsBuilder/components/EntryType.tsx
@@ -1,6 +1,7 @@
 import { ObjectOrArrayEntry } from './EntryTypes/ObjectOrArrayEntry';
 import { ExistsEntry } from './EntryTypes/ExistsEntry';
 import { ArrayEntry } from './EntryTypes/ArrayEntry';
+import { SessionVarEntry } from './EntryTypes/SessionVarEntry';
 import { isColumnComparator } from './utils';
 import { ColumnComparatorEntry } from './EntryTypes/ColumnComparatorEntry';
 import { useOperators } from './utils/comparatorsFromSchema';
@@ -52,6 +53,9 @@ export const EntryType = ({
       return null;
     }
     return <ExistsEntry k={k} v={v} path={path} />;
+  }
+  if (k === '_seq' || k === '_sne' || k === '_scontains' || k === '_sin') {
+    return <SessionVarEntry k={k} v={v} path={path} />;
   }
   if (
     operator?.name === '_contains' ||

--- a/frontend/libs/console/legacy-ce/src/lib/features/Permissions/PermissionsForm/components/RowPermissionsBuilder/components/EntryTypes/SessionVarEntry.integration.test.tsx
+++ b/frontend/libs/console/legacy-ce/src/lib/features/Permissions/PermissionsForm/components/RowPermissionsBuilder/components/EntryTypes/SessionVarEntry.integration.test.tsx
@@ -1,0 +1,345 @@
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { SessionVarEntry } from './SessionVarEntry';
+import { rowPermissionsContext } from '../RowPermissionsProvider';
+
+// Mock the entire permissions form context
+const createMockContext = (initialValues = {}) => {
+  const mockSetValue = jest.fn();
+  
+  return {
+    operators: {
+      sessionVar: {
+        label: 'Session variable operators',
+        items: [
+          { name: '_seq (equals)', value: '_seq' },
+          { name: '_sne (not equals)', value: '_sne' },
+          { name: '_scontains (contains)', value: '_scontains' },
+          { name: '_sin (in list)', value: '_sin' },
+        ],
+      },
+    },
+    permissions: initialValues,
+    comparators: {},
+    setValue: mockSetValue,
+    setKey: jest.fn(),
+    setPermissions: jest.fn(),
+    loadRelationships: jest.fn(),
+    isLoading: false,
+  };
+};
+
+const renderWithContext = (component: React.ReactElement, contextValue: any) => {
+  return render(
+    <rowPermissionsContext.Provider value={contextValue}>
+      {component}
+    </rowPermissionsContext.Provider>
+  );
+};
+
+describe('SessionVarEntry Integration Tests', () => {
+  let user: ReturnType<typeof userEvent.setup>;
+
+  beforeEach(() => {
+    user = userEvent.setup();
+    jest.clearAllMocks();
+  });
+
+  describe('Complete user workflows', () => {
+    it('allows user to create a complete _seq condition', async () => {
+      const mockContext = createMockContext();
+      
+      renderWithContext(
+        <SessionVarEntry
+          k="_seq"
+          v={{}}
+          path={['filter']}
+        />,
+        mockContext
+      );
+
+      // User enters session variable name
+      const varInput = screen.getByPlaceholderText('e.g., x-hasura-permissions');
+      await user.type(varInput, 'X-Hasura-User-Id');
+      
+      expect(mockContext.setValue).toHaveBeenCalledWith(['filter', 'var'], 'X-Hasura-User-Id');
+
+      // User enters value
+      const valueInput = screen.getByPlaceholderText('e.g., view:projects');
+      await user.type(valueInput, '123');
+      
+      expect(mockContext.setValue).toHaveBeenCalledWith(['filter', 'value'], '123');
+    });
+
+    it('allows user to create a complete _sin condition with multiple values', async () => {
+      const mockContext = createMockContext();
+      
+      renderWithContext(
+        <SessionVarEntry
+          k="_sin"
+          v={{}}
+          path={['filter']}
+        />,
+        mockContext
+      );
+
+      // User enters session variable name
+      const varInput = screen.getByPlaceholderText('e.g., x-hasura-permissions');
+      await user.type(varInput, 'X-Hasura-Groups');
+      
+      expect(mockContext.setValue).toHaveBeenCalledWith(['filter', 'var'], 'X-Hasura-Groups');
+
+      // User enters comma-separated values
+      const valueInput = screen.getByPlaceholderText('value1,value2,value3');
+      await user.type(valueInput, 'admin,editor,viewer');
+      
+      expect(mockContext.setValue).toHaveBeenCalledWith(['filter', 'value'], 'admin,editor,viewer');
+
+      // Verify help text is shown
+      expect(screen.getByText('For multiple values, separate with commas')).toBeInTheDocument();
+    });
+
+    it('handles editing existing session variable conditions', async () => {
+      const mockContext = createMockContext();
+      
+      renderWithContext(
+        <SessionVarEntry
+          k="_scontains"
+          v={{ var: 'X-Hasura-Permissions', value: 'view:projects' }}
+          path={['filter']}
+        />,
+        mockContext
+      );
+
+      // Verify existing values are displayed
+      expect(screen.getByDisplayValue('X-Hasura-Permissions')).toBeInTheDocument();
+      expect(screen.getByDisplayValue('view:projects')).toBeInTheDocument();
+
+      // User modifies the value
+      const valueInput = screen.getByDisplayValue('view:projects');
+      await user.clear(valueInput);
+      await user.type(valueInput, 'edit:projects');
+      
+      expect(mockContext.setValue).toHaveBeenCalledWith(['filter', 'value'], 'edit:projects');
+    });
+
+    it('provides clear visual feedback for different operators', () => {
+      const operators = [
+        { key: '_seq', label: 'Session variable equals' },
+        { key: '_sne', label: 'Session variable not equals' },
+        { key: '_scontains', label: 'Session variable contains' },
+        { key: '_sin', label: 'Session variable in list' },
+      ];
+
+      operators.forEach(({ key, label }) => {
+        const mockContext = createMockContext();
+        const { unmount } = renderWithContext(
+          <SessionVarEntry
+            k={key}
+            v={{ var: 'test', value: 'test' }}
+            path={['filter']}
+          />,
+          mockContext
+        );
+
+        expect(screen.getByText(label)).toBeInTheDocument();
+        unmount();
+      });
+    });
+  });
+
+  describe('Error handling and edge cases', () => {
+    it('gracefully handles rapid typing without losing data', async () => {
+      const mockContext = createMockContext();
+      
+      renderWithContext(
+        <SessionVarEntry
+          k="_seq"
+          v={{}}
+          path={['filter']}
+        />,
+        mockContext
+      );
+
+      const varInput = screen.getByPlaceholderText('e.g., x-hasura-permissions');
+      
+      // Simulate rapid typing
+      await user.type(varInput, 'X-Hasura-User-Id', { delay: 1 });
+      
+      // Should have called setValue for each character or the final value
+      expect(mockContext.setValue).toHaveBeenCalled();
+      
+      // Get the last call to verify final value
+      const lastCall = mockContext.setValue.mock.calls[mockContext.setValue.mock.calls.length - 1];
+      expect(lastCall[1]).toBe('X-Hasura-User-Id');
+    });
+
+    it('handles very long session variable names', async () => {
+      const mockContext = createMockContext();
+      
+      renderWithContext(
+        <SessionVarEntry
+          k="_seq"
+          v={{}}
+          path={['filter']}
+        />,
+        mockContext
+      );
+
+      const longName = 'X-Hasura-Very-Long-Session-Variable-Name-That-Exceeds-Normal-Length';
+      const varInput = screen.getByPlaceholderText('e.g., x-hasura-permissions');
+      
+      await user.type(varInput, longName);
+      
+      expect(mockContext.setValue).toHaveBeenCalledWith(['filter', 'var'], longName);
+      expect(screen.getByDisplayValue(longName)).toBeInTheDocument();
+    });
+
+    it('handles special characters in session variable names', async () => {
+      const mockContext = createMockContext();
+      
+      renderWithContext(
+        <SessionVarEntry
+          k="_seq"
+          v={{}}
+          path={['filter']}
+        />,
+        mockContext
+      );
+
+      const specialName = 'X-Hasura-User@Domain.com';
+      const varInput = screen.getByPlaceholderText('e.g., x-hasura-permissions');
+      
+      await user.type(varInput, specialName);
+      
+      expect(mockContext.setValue).toHaveBeenCalledWith(['filter', 'var'], specialName);
+      expect(screen.getByDisplayValue(specialName)).toBeInTheDocument();
+    });
+
+    it('handles complex values for _sin operator', async () => {
+      const mockContext = createMockContext();
+      
+      renderWithContext(
+        <SessionVarEntry
+          k="_sin"
+          v={{}}
+          path={['filter']}
+        />,
+        mockContext
+      );
+
+      const complexValues = 'admin,editor-role,viewer:read-only,guest user,special@domain.com';
+      const valueInput = screen.getByPlaceholderText('value1,value2,value3');
+      
+      await user.type(valueInput, complexValues);
+      
+      expect(mockContext.setValue).toHaveBeenCalledWith(['filter', 'value'], complexValues);
+      expect(screen.getByDisplayValue(complexValues)).toBeInTheDocument();
+    });
+  });
+
+  describe('Accessibility and usability', () => {
+    it('maintains focus flow between inputs', async () => {
+      const mockContext = createMockContext();
+      
+      renderWithContext(
+        <SessionVarEntry
+          k="_seq"
+          v={{}}
+          path={['filter']}
+        />,
+        mockContext
+      );
+
+      const varInput = screen.getByPlaceholderText('e.g., x-hasura-permissions');
+      const valueInput = screen.getByPlaceholderText('e.g., view:projects');
+
+      // Tab from var input to value input
+      varInput.focus();
+      await user.tab();
+      
+      expect(valueInput).toHaveFocus();
+    });
+
+    it('provides appropriate input labels for screen readers', () => {
+      const mockContext = createMockContext();
+      
+      renderWithContext(
+        <SessionVarEntry
+          k="_seq"
+          v={{}}
+          path={['filter']}
+        />,
+        mockContext
+      );
+
+      expect(screen.getByLabelText('Session Variable Name')).toBeInTheDocument();
+      expect(screen.getByLabelText('Value')).toBeInTheDocument();
+    });
+
+    it('shows different labels for _sin operator', () => {
+      const mockContext = createMockContext();
+      
+      renderWithContext(
+        <SessionVarEntry
+          k="_sin"
+          v={{}}
+          path={['filter']}
+        />,
+        mockContext
+      );
+
+      expect(screen.getByLabelText('Session Variable Name')).toBeInTheDocument();
+      expect(screen.getByLabelText('Values (comma-separated)')).toBeInTheDocument();
+    });
+  });
+
+  describe('Performance considerations', () => {
+    it('does not cause excessive re-renders on input changes', async () => {
+      const mockContext = createMockContext();
+      
+      // Spy on component renders (would need to wrap component with profiler in real test)
+      renderWithContext(
+        <SessionVarEntry
+          k="_seq"
+          v={{}}
+          path={['filter']}
+        />,
+        mockContext
+      );
+
+      const varInput = screen.getByPlaceholderText('e.g., x-hasura-permissions');
+      
+      // Type multiple characters
+      await user.type(varInput, 'test');
+      
+      // Should not cause UI to become unresponsive
+      expect(varInput).toBeInTheDocument();
+      expect(mockContext.setValue).toHaveBeenCalled();
+    });
+
+    it('handles large paste operations gracefully', async () => {
+      const mockContext = createMockContext();
+      
+      renderWithContext(
+        <SessionVarEntry
+          k="_sin"
+          v={{}}
+          path={['filter']}
+        />,
+        mockContext
+      );
+
+      const largeValue = Array.from({ length: 100 }, (_, i) => `value-${i}`).join(',');
+      const valueInput = screen.getByPlaceholderText('value1,value2,value3');
+      
+      // Simulate paste operation
+      await user.click(valueInput);
+      await user.paste(largeValue);
+      
+      expect(mockContext.setValue).toHaveBeenCalledWith(['filter', 'value'], largeValue);
+      expect(screen.getByDisplayValue(largeValue)).toBeInTheDocument();
+    });
+  });
+});

--- a/frontend/libs/console/legacy-ce/src/lib/features/Permissions/PermissionsForm/components/RowPermissionsBuilder/components/EntryTypes/SessionVarEntry.test.tsx
+++ b/frontend/libs/console/legacy-ce/src/lib/features/Permissions/PermissionsForm/components/RowPermissionsBuilder/components/EntryTypes/SessionVarEntry.test.tsx
@@ -1,0 +1,217 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { SessionVarEntry } from './SessionVarEntry';
+import { rowPermissionsContext } from '../RowPermissionsProvider';
+
+// Mock the context
+const mockSetValue = jest.fn();
+const mockContextValue = {
+  operators: {},
+  permissions: {},
+  comparators: {},
+  setValue: mockSetValue,
+  setKey: jest.fn(),
+  setPermissions: jest.fn(),
+  loadRelationships: jest.fn(),
+  isLoading: false,
+};
+
+const renderWithContext = (component: React.ReactElement) => {
+  return render(
+    <rowPermissionsContext.Provider value={mockContextValue}>
+      {component}
+    </rowPermissionsContext.Provider>
+  );
+};
+
+describe('SessionVarEntry', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('_seq operator', () => {
+    it('renders input fields for session variable and value', () => {
+      renderWithContext(
+        <SessionVarEntry
+          k="_seq"
+          v={{ var: 'X-Hasura-User-Id', value: '123' }}
+          path={['test']}
+        />
+      );
+
+      expect(screen.getByDisplayValue('X-Hasura-User-Id')).toBeInTheDocument();
+      expect(screen.getByDisplayValue('123')).toBeInTheDocument();
+      expect(screen.getByText('Session variable equals')).toBeInTheDocument();
+    });
+
+    it('handles empty values gracefully', () => {
+      renderWithContext(
+        <SessionVarEntry
+          k="_seq"
+          v={{}}
+          path={['test']}
+        />
+      );
+
+      expect(screen.getByPlaceholderText('e.g., x-hasura-permissions')).toBeInTheDocument();
+      expect(screen.getByPlaceholderText('e.g., view:projects')).toBeInTheDocument();
+    });
+
+    it('calls setValue when session variable name changes', () => {
+      renderWithContext(
+        <SessionVarEntry
+          k="_seq"
+          v={{ var: '', value: '' }}
+          path={['test']}
+        />
+      );
+
+      const varInput = screen.getByPlaceholderText('e.g., x-hasura-permissions');
+      fireEvent.change(varInput, { target: { value: 'X-Hasura-User-Id' } });
+
+      expect(mockSetValue).toHaveBeenCalledWith(['test', 'var'], 'X-Hasura-User-Id');
+    });
+
+    it('calls setValue when value changes', () => {
+      renderWithContext(
+        <SessionVarEntry
+          k="_seq"
+          v={{ var: '', value: '' }}
+          path={['test']}
+        />
+      );
+
+      const valueInput = screen.getByPlaceholderText('e.g., view:projects');
+      fireEvent.change(valueInput, { target: { value: '123' } });
+
+      expect(mockSetValue).toHaveBeenCalledWith(['test', 'value'], '123');
+    });
+  });
+
+  describe('_sne operator', () => {
+    it('renders with correct label', () => {
+      renderWithContext(
+        <SessionVarEntry
+          k="_sne"
+          v={{ var: 'X-Hasura-Role', value: 'admin' }}
+          path={['test']}
+        />
+      );
+
+      expect(screen.getByText('Session variable not equals')).toBeInTheDocument();
+    });
+  });
+
+  describe('_scontains operator', () => {
+    it('renders with correct label', () => {
+      renderWithContext(
+        <SessionVarEntry
+          k="_scontains"
+          v={{ var: 'X-Hasura-Permissions', value: 'view:projects' }}
+          path={['test']}
+        />
+      );
+
+      expect(screen.getByText('Session variable contains')).toBeInTheDocument();
+    });
+  });
+
+  describe('_sin operator', () => {
+    it('renders with correct label and placeholder', () => {
+      renderWithContext(
+        <SessionVarEntry
+          k="_sin"
+          v={{ var: 'X-Hasura-Groups', value: 'admin,editor' }}
+          path={['test']}
+        />
+      );
+
+      expect(screen.getByText('Session variable in list')).toBeInTheDocument();
+      expect(screen.getByText('Values (comma-separated)')).toBeInTheDocument();
+      expect(screen.getByPlaceholderText('value1,value2,value3')).toBeInTheDocument();
+      expect(screen.getByText('For multiple values, separate with commas')).toBeInTheDocument();
+    });
+
+    it('handles comma-separated values', () => {
+      renderWithContext(
+        <SessionVarEntry
+          k="_sin"
+          v={{ var: 'X-Hasura-Groups', value: 'admin,editor,viewer' }}
+          path={['test']}
+        />
+      );
+
+      expect(screen.getByDisplayValue('admin,editor,viewer')).toBeInTheDocument();
+    });
+  });
+
+  describe('Unknown operator', () => {
+    it('falls back to operator name when label not found', () => {
+      renderWithContext(
+        <SessionVarEntry
+          k="_sunknown"
+          v={{ var: 'X-Hasura-Test', value: 'test' }}
+          path={['test']}
+        />
+      );
+
+      expect(screen.getByText('Session variable _sunknown')).toBeInTheDocument();
+    });
+  });
+
+  describe('Null/undefined values', () => {
+    it('handles null value object', () => {
+      renderWithContext(
+        <SessionVarEntry
+          k="_seq"
+          v={null}
+          path={['test']}
+        />
+      );
+
+      // Should render empty inputs without crashing
+      expect(screen.getByPlaceholderText('e.g., x-hasura-permissions')).toBeInTheDocument();
+    });
+
+    it('handles undefined value object', () => {
+      renderWithContext(
+        <SessionVarEntry
+          k="_seq"
+          v={undefined}
+          path={['test']}
+        />
+      );
+
+      // Should render empty inputs without crashing
+      expect(screen.getByPlaceholderText('e.g., x-hasura-permissions')).toBeInTheDocument();
+    });
+  });
+
+  describe('Accessibility', () => {
+    it('has proper labels for inputs', () => {
+      renderWithContext(
+        <SessionVarEntry
+          k="_seq"
+          v={{ var: '', value: '' }}
+          path={['test']}
+        />
+      );
+
+      expect(screen.getByLabelText('Session Variable Name')).toBeInTheDocument();
+      expect(screen.getByLabelText('Value')).toBeInTheDocument();
+    });
+
+    it('has proper labels for _sin operator', () => {
+      renderWithContext(
+        <SessionVarEntry
+          k="_sin"
+          v={{ var: '', value: '' }}
+          path={['test']}
+        />
+      );
+
+      expect(screen.getByLabelText('Session Variable Name')).toBeInTheDocument();
+      expect(screen.getByLabelText('Values (comma-separated)')).toBeInTheDocument();
+    });
+  });
+});

--- a/frontend/libs/console/legacy-ce/src/lib/features/Permissions/PermissionsForm/components/RowPermissionsBuilder/components/EntryTypes/SessionVarEntry.tsx
+++ b/frontend/libs/console/legacy-ce/src/lib/features/Permissions/PermissionsForm/components/RowPermissionsBuilder/components/EntryTypes/SessionVarEntry.tsx
@@ -1,0 +1,71 @@
+import { useContext } from 'react';
+import { rowPermissionsContext } from '../RowPermissionsProvider';
+
+export function SessionVarEntry({
+  k,
+  v,
+  path,
+}: {
+  k: string;
+  v: any;
+  path: string[];
+}) {
+  const { setValue } = useContext(rowPermissionsContext);
+
+  // Initialize default structure if needed
+  const sessionVarValue = v || { var: '', value: '' };
+
+  const handleVarChange = (newVar: string) => {
+    setValue([...path, 'var'], newVar);
+  };
+
+  const handleValueChange = (newValue: string) => {
+    setValue([...path, 'value'], newValue);
+  };
+
+  const operatorLabels: Record<string, string> = {
+    '_seq': 'equals',
+    '_sne': 'not equals', 
+    '_scontains': 'contains',
+    '_sin': 'in list'
+  };
+
+  return (
+    <div className="space-y-2">
+      <div className="text-sm text-gray-600">
+        Session variable {operatorLabels[k] || k}
+      </div>
+      <div className="grid grid-cols-2 gap-4">
+        <div>
+          <label className="block text-xs font-medium text-gray-700 mb-1">
+            Session Variable Name
+          </label>
+          <input
+            type="text"
+            className="w-full border border-gray-300 rounded px-2 py-1 text-sm"
+            placeholder="e.g., x-hasura-permissions"
+            value={sessionVarValue.var || ''}
+            onChange={e => handleVarChange(e.target.value)}
+          />
+        </div>
+        <div>
+          <label className="block text-xs font-medium text-gray-700 mb-1">
+            {k === '_sin' ? 'Values (comma-separated)' : 'Value'}
+          </label>
+          <input
+            type="text"
+            className="w-full border border-gray-300 rounded px-2 py-1 text-sm"
+            placeholder={k === '_sin' ? 'value1,value2,value3' : 'e.g., view:projects'}
+            value={sessionVarValue.value || ''}
+            onChange={e => handleValueChange(e.target.value)}
+          />
+          {k === '_sin' && (
+            <div className="text-xs text-gray-500 mt-1">
+              For multiple values, separate with commas
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/libs/console/legacy-ce/src/lib/features/Permissions/PermissionsForm/components/RowPermissionsBuilder/components/EntryTypes/SessionVarEntry.tsx
+++ b/frontend/libs/console/legacy-ce/src/lib/features/Permissions/PermissionsForm/components/RowPermissionsBuilder/components/EntryTypes/SessionVarEntry.tsx
@@ -26,8 +26,8 @@ export function SessionVarEntry({
   const operatorLabels: Record<string, string> = {
     '_seq': 'equals',
     '_sne': 'not equals', 
-    '_scontains': 'contains',
-    '_sin': 'in list'
+    '_scontains': 'value in session list',
+    '_sin': 'session in value list'
   };
 
   return (
@@ -62,6 +62,11 @@ export function SessionVarEntry({
           {k === '_sin' && (
             <div className="text-xs text-gray-500 mt-1">
               For multiple values, separate with commas
+            </div>
+          )}
+          {k === '_scontains' && (
+            <div className="text-xs text-gray-500 mt-1">
+              Checks if this value is in the session variable list
             </div>
           )}
         </div>

--- a/frontend/libs/console/legacy-ce/src/lib/features/Permissions/PermissionsForm/components/RowPermissionsBuilder/components/Operator.tsx
+++ b/frontend/libs/console/legacy-ce/src/lib/features/Permissions/PermissionsForm/components/RowPermissionsBuilder/components/Operator.tsx
@@ -109,6 +109,15 @@ export const Operator = ({
           ))}
         </optgroup>
       ) : null}
+      {operators.sessionVar?.items.length ? (
+        <optgroup label="Session variable operators">
+          {operators.sessionVar.items.map((item, index) => (
+            <option data-type="sessionVar" key={'sessionVar' + index} value={item.value}>
+              {item.name}
+            </option>
+          ))}
+        </optgroup>
+      ) : null}
       {relationships.length ? (
         <optgroup label="Relationships">
           {relationships.map((item, index) => (

--- a/frontend/libs/console/legacy-ce/src/lib/features/Permissions/PermissionsForm/components/RowPermissionsBuilder/components/RowPermissionsInput.tsx
+++ b/frontend/libs/console/legacy-ce/src/lib/features/Permissions/PermissionsForm/components/RowPermissionsBuilder/components/RowPermissionsInput.tsx
@@ -55,6 +55,15 @@ export const RowPermissionsInput = ({
       label: 'Exist operators',
       items: [{ name: '_exists', value: '_exists' }],
     },
+    sessionVar: {
+      label: 'Session variable operators',
+      items: [
+        { name: '_seq (equals)', value: '_seq' },
+        { name: '_sne (not equals)', value: '_sne' },
+        { name: '_scontains (contains)', value: '_scontains' },
+        { name: '_sin (in list)', value: '_sin' },
+      ],
+    },
   };
   return (
     <ForbiddenFeaturesProvider forbidden={forbidden}>

--- a/frontend/libs/console/legacy-ce/src/lib/features/Permissions/PermissionsForm/components/RowPermissionsBuilder/components/RowPermissionsInput.tsx
+++ b/frontend/libs/console/legacy-ce/src/lib/features/Permissions/PermissionsForm/components/RowPermissionsBuilder/components/RowPermissionsInput.tsx
@@ -60,7 +60,7 @@ export const RowPermissionsInput = ({
       items: [
         { name: '_seq (equals)', value: '_seq' },
         { name: '_sne (not equals)', value: '_sne' },
-        { name: '_scontains (contains)', value: '_scontains' },
+        { name: '_scontains (value in session list)', value: '_scontains' },
         { name: '_sin (in list)', value: '_sin' },
       ],
     },

--- a/frontend/libs/console/legacy-ce/src/lib/features/Permissions/PermissionsForm/components/RowPermissionsBuilder/components/types.ts
+++ b/frontend/libs/console/legacy-ce/src/lib/features/Permissions/PermissionsForm/components/RowPermissionsBuilder/components/types.ts
@@ -47,7 +47,8 @@ export type PermissionType =
   | 'relationship'
   | 'object'
   | 'value'
-  | 'comparator';
+  | 'comparator'
+  | 'sessionVar';
 
 export type RowPermissionsState = {
   operators: Operators;

--- a/server/graphql-engine.cabal
+++ b/server/graphql-engine.cabal
@@ -1238,6 +1238,8 @@ test-suite graphql-engine-tests
     Hasura.Metadata.DTO.MetadataDTOSpec
     Hasura.QuickCheck.Instances
     Hasura.RQL.DDL.Webhook.TransformSpec
+    Hasura.RQL.IR.BoolExp.SessionVarSpec
+    Hasura.RQL.IR.BoolExp.SessionVarIntegrationSpec
     Hasura.RQL.IR.Generator
     Hasura.RQL.IR.SelectSpec
     Hasura.RQL.MetadataSpec

--- a/server/src-lib/Hasura/Backends/BigQuery/FromIr.hs
+++ b/server/src-lib/Hasura/Backends/BigQuery/FromIr.hs
@@ -1838,6 +1838,9 @@ fromGBoolExp =
       fmap OrExpression (traverse fromGBoolExp expressions)
     Ir.BoolNot expression -> fmap NotExpression (fromGBoolExp expression)
     Ir.BoolExists gExists -> fmap ExistsExpression (fromGExists gExists)
+    Ir.BoolSessionVar _sessionVarCondition ->
+      -- Session variable conditions are not currently supported in BigQuery backend
+      refute (pure (UnsupportedOpExpG Ir.ANISNULL))
     Ir.BoolField expression -> pure expression
 
 --------------------------------------------------------------------------------

--- a/server/src-lib/Hasura/Backends/DataConnector/Plan/Common.hs
+++ b/server/src-lib/Hasura/Backends/DataConnector/Plan/Common.hs
@@ -413,6 +413,10 @@ translateBoolExp sourceName columnStack = \case
         pure (fmap (J.String) result)
     pure
       $ API.ApplyBinaryArrayComparisonOperator API.In (API.ComparisonColumn API.CurrentTable (API.mkColumnSelector (API.ColumnName (toTxt colFld))) (API.ScalarType (toTxt lhsColType)) Nothing) lookupLst (API.ScalarType (toTxt lhsColType))
+  BoolSessionVar _sessionVarCondition ->
+    -- For now, session variable conditions are not supported in DataConnector
+    -- This could be enhanced in the future to pass session variable info to the connector
+    throwError $ err400 NotSupported "Session variable conditions are not yet supported in DataConnector backend"
   BoolExists GExists {..} ->
     let tableName = Witch.from _geTable
      in API.Exists (API.UnrelatedTable tableName) <$> translateBoolExp (API.TNTable tableName) emptyColumnStack _geWhere

--- a/server/src-lib/Hasura/Backends/MSSQL/FromIr/Expression.hs
+++ b/server/src-lib/Hasura/Backends/MSSQL/FromIr/Expression.hs
@@ -43,6 +43,9 @@ fromGBoolExp =
       fmap NotExpression (fromGBoolExp expression)
     IR.BoolExists gExists ->
       fromGExists gExists
+    IR.BoolSessionVar _sessionVarCondition ->
+      -- Session variable conditions are not currently supported in MSSQL backend
+      lift $ refute (pure (UnsupportedOpExpG IR.ANISNULL))
     IR.BoolField expression ->
       fromAnnBoolExpFld expression
   where

--- a/server/src-lib/Hasura/Backends/Postgres/Translate/BoolExp.hs
+++ b/server/src-lib/Hasura/Backends/Postgres/Translate/BoolExp.hs
@@ -9,9 +9,10 @@ module Hasura.Backends.Postgres.Translate.BoolExp
   )
 where
 
-import Data.Aeson (fromJSON, Result(..))
+import Data.Aeson (fromJSON, Result(..), eitherDecodeStrict)
 import Data.HashMap.Strict qualified as HashMap
 import Data.Text qualified as T
+import Data.Text.Encoding (encodeUtf8)
 import Data.Text.Extended (ToTxt, toTxt)
 import Hasura.Authentication.Session (getSessionVariableValue)
 import Hasura.Authentication.User (UserInfo (..))
@@ -155,10 +156,14 @@ translateBoolExp userInfo = \case
                 S.BELit $ sessionValue /= expectedValue
               _ -> S.BELit False
           SVOContains ->
-            case fromJSON value of
-              Success (expectedValue :: T.Text) -> 
-                S.BELit $ expectedValue `T.isInfixOf` sessionValue
-              _ -> S.BELit False
+            -- Parse session variable as JSON array and check if value is in it
+            case eitherDecodeStrict (encodeUtf8 sessionValue) of
+              Right (sessionList :: [T.Text]) ->
+                case fromJSON value of
+                  Success (expectedValue :: T.Text) -> 
+                    S.BELit $ expectedValue `elem` sessionList
+                  _ -> S.BELit False
+              _ -> S.BELit False -- Session var is not a valid JSON array
           SVOIn ->
             case fromJSON value of
               Success (expectedList :: [T.Text]) -> 

--- a/server/src-lib/Hasura/Backends/Postgres/Translate/BoolExp.hs
+++ b/server/src-lib/Hasura/Backends/Postgres/Translate/BoolExp.hs
@@ -9,8 +9,11 @@ module Hasura.Backends.Postgres.Translate.BoolExp
   )
 where
 
+import Data.Aeson (fromJSON, Result(..))
 import Data.HashMap.Strict qualified as HashMap
+import Data.Text qualified as T
 import Data.Text.Extended (ToTxt, toTxt)
+import Hasura.Authentication.Session (fromSessionVariable)
 import Hasura.Authentication.User (UserInfo (..))
 import Hasura.Backends.Postgres.SQL.DML qualified as S
 import Hasura.Backends.Postgres.SQL.Types hiding (TableName)
@@ -128,6 +131,31 @@ translateBoolExp userInfo = \case
 
     whereExp <- withCurrentTable (S.QualifiedIdentifier identifier Nothing) (translateBoolExp userInfo wh)
     return $ S.mkExists (S.FISimple currTableReference (Just alias)) whereExp
+  BoolSessionVar (SessionVarCondition op var value) -> do
+    -- Generate dynamic SQL that accesses session variables at execution time
+    -- instead of resolving them at planning time
+    let sessionVarAccessor = S.SEOpApp (S.SQLOp "->>") [S.SEPrep 1, S.SELit $ fromSessionVariable var]
+    pure $ case op of
+      SVOEquals ->
+        case fromJSON value of
+          Success (expectedValue :: T.Text) -> 
+            S.BECompare S.SEQ sessionVarAccessor (S.SELit expectedValue)
+          _ -> S.BELit False
+      SVONotEquals ->
+        case fromJSON value of
+          Success (expectedValue :: T.Text) -> 
+            S.BECompare S.SNE sessionVarAccessor (S.SELit expectedValue)
+          _ -> S.BELit False
+      SVOContains ->
+        case fromJSON value of
+          Success (expectedValue :: T.Text) -> 
+            S.BECompare S.SContains sessionVarAccessor (S.SELit expectedValue)
+          _ -> S.BELit False
+      SVOIn ->
+        case fromJSON value of
+          Success (expectedList :: [T.Text]) -> 
+            S.BECompareAny S.SEQ sessionVarAccessor (S.SETyAnn (S.SEArray (map S.SELit expectedList)) (S.TypeAnn "text[]"))
+          _ -> S.BELit False
   BoolField boolExp -> case boolExp of
     AVColumn colInfo redactionExp opExps -> do
       BoolExpCtx {rootReference, currTableReference} <- ask
@@ -526,3 +554,4 @@ withRedactionExp tableQual redactionExp userInfo sqlExpression =
     RedactIfFalse gBoolExp -> do
       boolExp <- S.simplifyBoolExp <$> toSQLBoolExp userInfo tableQual gBoolExp
       pure $ S.SECond boolExp sqlExpression S.SENull
+

--- a/server/src-lib/Hasura/Backends/Postgres/Translate/BoolExp.hs
+++ b/server/src-lib/Hasura/Backends/Postgres/Translate/BoolExp.hs
@@ -13,7 +13,7 @@ import Data.Aeson (fromJSON, Result(..))
 import Data.HashMap.Strict qualified as HashMap
 import Data.Text qualified as T
 import Data.Text.Extended (ToTxt, toTxt)
-import Hasura.Authentication.Session (fromSessionVariable)
+import Hasura.Authentication.Session (getSessionVariableValue)
 import Hasura.Authentication.User (UserInfo (..))
 import Hasura.Backends.Postgres.SQL.DML qualified as S
 import Hasura.Backends.Postgres.SQL.Types hiding (TableName)
@@ -132,30 +132,38 @@ translateBoolExp userInfo = \case
     whereExp <- withCurrentTable (S.QualifiedIdentifier identifier Nothing) (translateBoolExp userInfo wh)
     return $ S.mkExists (S.FISimple currTableReference (Just alias)) whereExp
   BoolSessionVar (SessionVarCondition op var value) -> do
-    -- Generate dynamic SQL that accesses session variables at execution time
-    -- instead of resolving them at planning time
-    let sessionVarAccessor = S.SEOpApp (S.SQLOp "->>") [S.SEPrep 1, S.SELit $ fromSessionVariable var]
-    pure $ case op of
-      SVOEquals ->
-        case fromJSON value of
-          Success (expectedValue :: T.Text) -> 
-            S.BECompare S.SEQ sessionVarAccessor (S.SELit expectedValue)
-          _ -> S.BELit False
-      SVONotEquals ->
-        case fromJSON value of
-          Success (expectedValue :: T.Text) -> 
-            S.BECompare S.SNE sessionVarAccessor (S.SELit expectedValue)
-          _ -> S.BELit False
-      SVOContains ->
-        case fromJSON value of
-          Success (expectedValue :: T.Text) -> 
-            S.BECompare S.SContains sessionVarAccessor (S.SELit expectedValue)
-          _ -> S.BELit False
-      SVOIn ->
-        case fromJSON value of
-          Success (expectedList :: [T.Text]) -> 
-            S.BECompareAny S.SEQ sessionVarAccessor (S.SETyAnn (S.SEArray (map S.SELit expectedList)) (S.TypeAnn "text[]"))
-          _ -> S.BELit False
+    -- Check if we have session variables available and can resolve this specific variable
+    let sessionVars = _uiSession userInfo
+        sessionValueMaybe = getSessionVariableValue var sessionVars
+    case sessionValueMaybe of
+      Nothing -> do
+        -- Session variable not available (EXPLAIN without session context or missing variable)
+        -- Generate SQL that will evaluate to false, allowing EXPLAIN to work
+        pure $ S.BELit False
+      Just sessionValue -> do
+        -- Session variable is available - resolve immediately to avoid parameter binding issues
+        -- This works for both normal queries and EXPLAIN queries
+        pure $ case op of
+          SVOEquals ->
+            case fromJSON value of
+              Success (expectedValue :: T.Text) -> 
+                S.BELit $ sessionValue == expectedValue
+              _ -> S.BELit False
+          SVONotEquals ->
+            case fromJSON value of
+              Success (expectedValue :: T.Text) -> 
+                S.BELit $ sessionValue /= expectedValue
+              _ -> S.BELit False
+          SVOContains ->
+            case fromJSON value of
+              Success (expectedValue :: T.Text) -> 
+                S.BELit $ expectedValue `T.isInfixOf` sessionValue
+              _ -> S.BELit False
+          SVOIn ->
+            case fromJSON value of
+              Success (expectedList :: [T.Text]) -> 
+                S.BELit $ sessionValue `elem` expectedList
+              _ -> S.BELit False
   BoolField boolExp -> case boolExp of
     AVColumn colInfo redactionExp opExps -> do
       BoolExpCtx {rootReference, currTableReference} <- ask

--- a/server/src-lib/Hasura/RQL/DDL/Permission/Internal.hs
+++ b/server/src-lib/Hasura/RQL/DDL/Permission/Internal.hs
@@ -177,6 +177,9 @@ annBoolExp rhsParser rootFieldInfoMap fim boolExp =
         refFields <- withPathK "_table" $ askFieldInfoMapSource refqt
         annWhereExp <- withPathK "_where" $ annBoolExp rhsParser rootFieldInfoMap refFields whereExp
         return $ BoolExists $ GExists refqt annWhereExp
+    BoolSessionVar sessionVarCondition ->
+      -- Session variable conditions pass through unchanged in annotation
+      return $ BoolSessionVar sessionVarCondition
     BoolField fld -> BoolField <$> annColExp rhsParser rootFieldInfoMap fim fld
   where
     procExps = mapM (annBoolExp rhsParser rootFieldInfoMap fim)

--- a/server/src-lib/Hasura/RQL/DDL/Schema/Rename.hs
+++ b/server/src-lib/Hasura/RQL/DDL/Schema/Rename.hs
@@ -488,6 +488,9 @@ updateFieldInBoolExp qt rf be =
           . GExists refqt
           . unBoolExp
           <$> updateFieldInBoolExp refqt rf (BoolExp wh)
+      BoolSessionVar sessionVarCondition ->
+        -- Session variable conditions don't need field renaming
+        pure $ BoolSessionVar sessionVarCondition
       BoolField fld -> BoolField <$> updateColExp qt rf fld
   where
     procExps = mapM updateBoolExp'

--- a/server/src-lib/Hasura/RQL/IR/BoolExp.hs
+++ b/server/src-lib/Hasura/RQL/IR/BoolExp.hs
@@ -12,6 +12,8 @@ module Hasura.RQL.IR.BoolExp
     GBoolExp (..),
     gBoolExpTrue,
     GExists (..),
+    SessionVarCondition (..),
+    SessionVarOperator (..),
     DWithinGeomOp (..),
     DWithinGeogOp (..),
     CastExp,
@@ -71,6 +73,46 @@ import Hasura.RQL.Types.Relationships.Local
 import Hasura.SQL.AnyBackend qualified as AB
 
 ----------------------------------------------------------------------------------------------------
+-- Session Variable Conditions
+
+-- | Represents a condition on a session variable. This allows checking session variables
+-- directly in boolean expressions as peers to _and, _or, _not, _exists.
+data SessionVarCondition = SessionVarCondition
+  { svcOperator :: SessionVarOperator,
+    svcVariable :: SessionVariable,
+    svcValue :: Value
+  }
+  deriving (Show, Eq, Generic, Data)
+
+instance NFData SessionVarCondition
+
+instance Hashable SessionVarCondition
+
+-- | Session variable operators for direct comparison
+data SessionVarOperator
+  = SVOEquals -- _seq
+  | SVONotEquals -- _sne  
+  | SVOContains -- _scontains
+  | SVOIn -- _sin
+  deriving (Show, Eq, Generic, Data)
+
+instance NFData SessionVarOperator
+
+instance Hashable SessionVarOperator
+
+instance FromJSON SessionVarCondition where
+  parseJSON = withObject "SessionVarCondition" $ \o -> do
+    var <- o .: "var"
+    value <- o .: "value"
+    -- The operator is determined by the parent key (_seq, _sne, etc.)
+    -- This will be handled in the parent parsing context
+    pure $ SessionVarCondition SVOEquals var value
+
+instance ToJSON SessionVarCondition where
+  toJSON (SessionVarCondition _op var value) =
+    object ["var" .= var, "value" .= value]
+
+----------------------------------------------------------------------------------------------------
 -- Boolean structure
 
 -- | This type represents a boolean expression tree. It is parametric over the actual
@@ -88,6 +130,8 @@ data GBoolExp (backend :: BackendType) field
     -- since the @backend@ and @field@ are the same,
     -- the table must be of the same database type.
     BoolExists (GExists backend field)
+  | -- | A session variable condition
+    BoolSessionVar SessionVarCondition
   | -- | A column field
     BoolField field
   deriving (Show, Functor, Foldable, Traversable, Data, Generic)
@@ -101,8 +145,12 @@ instance (Backend b, Data a) => Plated (GBoolExp b a)
 instance (Backend b, Hashable a) => Hashable (GBoolExp b a)
 
 instance (Backend b, FromJSONKeyValue a) => FromJSON (GBoolExp b a) where
-  parseJSON = withObject "boolean expression" \o ->
-    BoolAnd <$> forM (KM.toList o) \(k, v) ->
+  parseJSON = withObject "boolean expression" $ \o -> do
+    let parseSessionVarCondition op = withObject "session variable condition" $ \obj -> do
+          var <- obj .: "var"
+          value <- obj .: "value"
+          pure $ SessionVarCondition op var value
+    BoolAnd <$> forM (KM.toList o) (\(k, v) ->
       if
         | k == "$or" -> BoolOr <$> parseJSON v <?> Key k
         | k == "_or" -> BoolOr <$> parseJSON v <?> Key k
@@ -112,7 +160,11 @@ instance (Backend b, FromJSONKeyValue a) => FromJSON (GBoolExp b a) where
         | k == "_not" -> BoolNot <$> parseJSON v <?> Key k
         | k == "$exists" -> BoolExists <$> parseJSON v <?> Key k
         | k == "_exists" -> BoolExists <$> parseJSON v <?> Key k
-        | otherwise -> BoolField <$> parseJSONKeyValue (k, v)
+        | k == "_seq" -> BoolSessionVar <$> parseSessionVarCondition SVOEquals v <?> Key k
+        | k == "_sne" -> BoolSessionVar <$> parseSessionVarCondition SVONotEquals v <?> Key k
+        | k == "_scontains" -> BoolSessionVar <$> parseSessionVarCondition SVOContains v <?> Key k
+        | k == "_sin" -> BoolSessionVar <$> parseSessionVarCondition SVOIn v <?> Key k
+        | otherwise -> BoolField <$> parseJSONKeyValue (k, v))
 
 instance (Backend backend, ToJSONKeyValue field) => ToJSON (GBoolExp backend field) where
   -- A representation for boolean values as JSON.
@@ -135,7 +187,17 @@ instance (Backend backend, ToJSONKeyValue field) => ToJSON (GBoolExp backend fie
         BoolOr bExps -> "_or" .= map toJSON bExps
         BoolNot bExp -> "_not" .= toJSON bExp
         BoolExists bExists -> "_exists" .= toJSON bExists
+        BoolSessionVar sessionCond -> sessionVarConditionToJSON sessionCond
         BoolField a -> toJSONKeyValue a
+      
+      sessionVarConditionToJSON :: SessionVarCondition -> (Key, Value)
+      sessionVarConditionToJSON (SessionVarCondition op var value) =
+        let opKey = case op of
+              SVOEquals -> "_seq"
+              SVONotEquals -> "_sne" 
+              SVOContains -> "_scontains"
+              SVOIn -> "_sin"
+        in opKey .= object ["var" .= var, "value" .= value]
 
 -- | A default representation for a @true@ boolean value.
 gBoolExpTrue :: GBoolExp backend field

--- a/server/src-lib/Hasura/RQL/IR/ModelInformation.hs
+++ b/server/src-lib/Hasura/RQL/IR/ModelInformation.hs
@@ -235,6 +235,7 @@ getArgumentModelNamesGen sourceName modelSourceType args = case args of
   BoolAnd args' -> for_ args' (getArgumentModelNamesGen sourceName modelSourceType)
   BoolOr args' -> for_ args' (getArgumentModelNamesGen sourceName modelSourceType)
   BoolNot args' -> getArgumentModelNamesGen sourceName modelSourceType args'
+  BoolSessionVar _ -> pure () -- Session variable conditions don't reference models
   BoolExists g -> do
     getArgumentModelNamesGen sourceName modelSourceType $ _geWhere g
   BoolField field -> case field of

--- a/server/src-lib/Hasura/RQL/Types/SchemaCache.hs
+++ b/server/src-lib/Hasura/RQL/Types/SchemaCache.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE UndecidableInstances #-}
 -- ghc 9.6 seems to be doing something screwy with...
 {-# OPTIONS_GHC -Wno-redundant-constraints #-}

--- a/server/src-lib/Hasura/RQL/Types/SchemaCache.hs
+++ b/server/src-lib/Hasura/RQL/Types/SchemaCache.hs
@@ -788,6 +788,7 @@ getLogicalModelBoolExpDeps source logicalModelLocation = \case
   BoolAnd exps -> concatMap (getLogicalModelBoolExpDeps source logicalModelLocation) exps
   BoolOr exps -> concatMap (getLogicalModelBoolExpDeps source logicalModelLocation) exps
   BoolNot e -> getLogicalModelBoolExpDeps source logicalModelLocation e
+  BoolSessionVar _ -> [] -- Session variable conditions don't create schema dependencies
   BoolField fld -> getLogicalModelColExpDeps source logicalModelLocation fld
   BoolExists (GExists refqt whereExp) -> do
     let table :: SchemaObjId
@@ -848,6 +849,7 @@ getBoolExpDeps' = \case
   BoolAnd exps -> procExps exps
   BoolOr exps -> procExps exps
   BoolNot e -> getBoolExpDeps' e
+  BoolSessionVar _ -> pure [] -- Session variable conditions don't create schema dependencies
   BoolField fld -> getColExpDeps fld
   BoolExists (GExists refqt whereExp) -> do
     BoolExpCtx {source} <- ask

--- a/server/src-test/Hasura/RQL/IR/BoolExp/SessionVarIntegrationSpec.hs
+++ b/server/src-test/Hasura/RQL/IR/BoolExp/SessionVarIntegrationSpec.hs
@@ -5,7 +5,7 @@
 module Hasura.RQL.IR.BoolExp.SessionVarIntegrationSpec (spec) where
 
 import Data.Aeson (Value (..), fromJSON, toJSON, Result(..))
-import Data.Aeson qualified as A
+import Data.Aeson qualified as J
 import Data.Aeson.QQ (aesonQQ)
 import Data.Text (Text) -- Used for type annotations
 import Hasura.Prelude
@@ -79,4 +79,4 @@ spec = do
         
         case result of
           Success roundTripBoolExp -> roundTripBoolExp `shouldBe` originalBoolExp
-          A.Error err -> expectationFailure $ "Round-trip failed: " <> err
+          J.Error err -> expectationFailure $ "Round-trip failed: " <> err

--- a/server/src-test/Hasura/RQL/IR/BoolExp/SessionVarIntegrationSpec.hs
+++ b/server/src-test/Hasura/RQL/IR/BoolExp/SessionVarIntegrationSpec.hs
@@ -1,0 +1,82 @@
+{-# LANGUAGE QuasiQuotes #-}
+{-# OPTIONS_GHC -Wno-unused-imports #-}
+
+-- | Integration tests for session variable operators in real permission scenarios.
+module Hasura.RQL.IR.BoolExp.SessionVarIntegrationSpec (spec) where
+
+import Data.Aeson (Value (..), fromJSON, toJSON, Result(..))
+import Data.Aeson qualified as A
+import Data.Aeson.QQ (aesonQQ)
+import Data.Text (Text) -- Used for type annotations
+import Hasura.Prelude
+import Hasura.RQL.IR.BoolExp (GBoolExp(..), SessionVarCondition(..), SessionVarOperator(..), ColExp(..))
+import Hasura.Authentication.Session (unsafeMkSessionVariable)
+import Hasura.RQL.Types.BackendType (BackendType (Postgres), PostgresKind (Vanilla))
+import Hasura.Backends.Postgres.Instances.Schema ()
+import Test.Hspec
+
+type PG = 'Postgres 'Vanilla
+
+spec :: Spec
+spec = do
+  describe "Session Variable Operators Integration" $ do
+    describe "Real-world permission scenarios" $ do
+      it "supports user isolation with _seq" $ do
+        let permissionJson = [aesonQQ|{
+          "_seq": {
+            "var": "X-Hasura-User-Id", 
+            "value": "user-123"
+          }
+        }|]
+        let result = fromJSON permissionJson :: Result (GBoolExp PG ColExp)
+        case result of
+          Success (BoolAnd [BoolSessionVar condition]) -> do
+            svcOperator condition `shouldBe` SVOEquals
+            svcVariable condition `shouldBe` unsafeMkSessionVariable ("X-Hasura-User-Id" :: Text)
+            svcValue condition `shouldBe` String "user-123"
+          _ -> expectationFailure $ "Failed to parse user isolation permission: " <> show result
+
+      it "supports role-based access with _sne" $ do
+        let permissionJson = [aesonQQ|{
+          "_sne": {
+            "var": "X-Hasura-Role", 
+            "value": "guest"
+          }
+        }|]
+        let result = fromJSON permissionJson :: Result (GBoolExp PG ColExp)
+        case result of
+          Success (BoolAnd [BoolSessionVar condition]) -> do
+            svcOperator condition `shouldBe` SVONotEquals
+            svcVariable condition `shouldBe` unsafeMkSessionVariable ("X-Hasura-Role" :: Text)
+            svcValue condition `shouldBe` String "guest"
+          _ -> expectationFailure $ "Failed to parse role exclusion permission: " <> show result
+
+      it "supports complex permission combinations" $ do
+        let permissionJson = [aesonQQ|{
+          "_or": [
+            {"_seq": {"var": "X-Hasura-User-Id", "value": "user-123"}},
+            {"_scontains": {"var": "X-Hasura-Permissions", "value": "admin"}}
+          ]
+        }|]
+        let result = fromJSON permissionJson :: Result (GBoolExp PG ColExp)
+        case result of
+          Success (BoolAnd [BoolOr conditions]) -> do
+            length conditions `shouldBe` 2
+            case conditions of
+              [BoolAnd [BoolSessionVar userCond], BoolAnd [BoolSessionVar adminCond]] -> do
+                svcOperator userCond `shouldBe` SVOEquals
+                svcOperator adminCond `shouldBe` SVOContains
+              _ -> expectationFailure $ "Unexpected condition structure: " <> show conditions
+          _ -> expectationFailure $ "Failed to parse complex permission: " <> show result
+
+    describe "Serialization round-trip" $ do
+      it "maintains structure through JSON round-trip" $ do
+        let originalCondition = SessionVarCondition SVOEquals (unsafeMkSessionVariable ("X-Hasura-User-Id" :: Text)) (String "123")
+        let originalBoolExp = BoolAnd [BoolSessionVar originalCondition] :: GBoolExp PG ColExp
+        
+        let json = toJSON originalBoolExp
+        let result = fromJSON json :: Result (GBoolExp PG ColExp)
+        
+        case result of
+          Success roundTripBoolExp -> roundTripBoolExp `shouldBe` originalBoolExp
+          A.Error err -> expectationFailure $ "Round-trip failed: " <> err

--- a/server/src-test/Hasura/RQL/IR/BoolExp/SessionVarSpec.hs
+++ b/server/src-test/Hasura/RQL/IR/BoolExp/SessionVarSpec.hs
@@ -1,0 +1,78 @@
+{-# LANGUAGE QuasiQuotes #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# OPTIONS_GHC -Wno-unused-imports #-}
+
+-- | This module tests the session variable operators in boolean expressions.
+module Hasura.RQL.IR.BoolExp.SessionVarSpec (spec) where
+
+import Data.Aeson (Value (..), fromJSON, toJSON, Result(..))
+import Data.Aeson.QQ (aesonQQ)
+import Data.Text (Text)
+import Hasura.Prelude
+import Hasura.RQL.IR.BoolExp (GBoolExp(..), SessionVarCondition(..), SessionVarOperator(..), ColExp(..))
+import Hasura.Authentication.Session (unsafeMkSessionVariable)
+import Hasura.RQL.Types.BackendType (BackendType (Postgres), PostgresKind (Vanilla))
+import Hasura.Backends.Postgres.Instances.Schema ()
+import Test.Hspec
+import qualified Data.Vector as Vector
+
+type PG = 'Postgres 'Vanilla
+
+spec :: Spec
+spec = do
+  describe "Session Variable Operators" $ do
+    describe "JSON Parsing" $ do
+      it "parses _seq operator correctly" $ do
+        let json = [aesonQQ|{"_seq": {"var": "X-Hasura-User-Id", "value": "123"}}|]
+        let result = fromJSON json :: Result (GBoolExp PG ColExp)
+        case result of
+          Success (BoolAnd [BoolSessionVar condition]) -> do
+            svcOperator condition `shouldBe` SVOEquals
+            svcVariable condition `shouldBe` unsafeMkSessionVariable ("X-Hasura-User-Id" :: Text)
+            svcValue condition `shouldBe` String "123"
+          _ -> expectationFailure $ "Failed to parse _seq: " <> show result
+
+      it "parses _sne operator correctly" $ do
+        let json = [aesonQQ|{"_sne": {"var": "X-Hasura-Role", "value": "admin"}}|]
+        let result = fromJSON json :: Result (GBoolExp PG ColExp)
+        case result of
+          Success (BoolAnd [BoolSessionVar condition]) -> do
+            svcOperator condition `shouldBe` SVONotEquals
+            svcVariable condition `shouldBe` unsafeMkSessionVariable ("X-Hasura-Role" :: Text)
+            svcValue condition `shouldBe` String "admin"
+          _ -> expectationFailure $ "Failed to parse _sne: " <> show result
+
+      it "parses _scontains operator correctly" $ do
+        let json = [aesonQQ|{"_scontains": {"var": "X-Hasura-Permissions", "value": "view:projects"}}|]
+        let result = fromJSON json :: Result (GBoolExp PG ColExp)
+        case result of
+          Success (BoolAnd [BoolSessionVar condition]) -> do
+            svcOperator condition `shouldBe` SVOContains
+            svcVariable condition `shouldBe` unsafeMkSessionVariable ("X-Hasura-Permissions" :: Text)
+            svcValue condition `shouldBe` String "view:projects"
+          _ -> expectationFailure $ "Failed to parse _scontains: " <> show result
+
+      it "parses _sin operator correctly" $ do
+        let json = [aesonQQ|{"_sin": {"var": "X-Hasura-Groups", "value": ["admin", "editor"]}}|]
+        let result = fromJSON json :: Result (GBoolExp PG ColExp)
+        case result of
+          Success (BoolAnd [BoolSessionVar condition]) -> do
+            svcOperator condition `shouldBe` SVOIn
+            svcVariable condition `shouldBe` unsafeMkSessionVariable ("X-Hasura-Groups" :: Text)
+            svcValue condition `shouldBe` Array (Vector.fromList ["admin", "editor"])
+          _ -> expectationFailure $ "Failed to parse _sin: " <> show result
+
+    describe "JSON Serialization" $ do
+      it "serializes _seq operator correctly" $ do
+        let condition = SessionVarCondition SVOEquals (unsafeMkSessionVariable ("X-Hasura-User-Id" :: Text)) (String "123")
+        let boolExp = BoolSessionVar condition :: GBoolExp PG ColExp
+        let json = toJSON boolExp
+        let expected = [aesonQQ|{"_seq": {"var": "X-Hasura-User-Id", "value": "123"}}|]
+        json `shouldBe` expected
+
+    describe "SessionVarOperator Show instances" $ do
+      it "shows operators correctly" $ do
+        show SVOEquals `shouldBe` "SVOEquals"
+        show SVONotEquals `shouldBe` "SVONotEquals"
+        show SVOContains `shouldBe` "SVOContains"
+        show SVOIn `shouldBe` "SVOIn"

--- a/server/test-drafts/SessionVarPropertySpec.hs
+++ b/server/test-drafts/SessionVarPropertySpec.hs
@@ -1,0 +1,67 @@
+{-# LANGUAGE StandaloneDeriving #-}
+
+-- | Property-based tests for session variable operators using QuickCheck.
+module Hasura.RQL.IR.BoolExp.SessionVarPropertySpec (spec) where
+
+import Data.Aeson (Value (..), Array, toJSON, fromJSON)
+import Data.Aeson qualified as A
+import Data.List (nub)
+import Data.Text (Text)
+import Hasura.Prelude
+import Hasura.RQL.IR.BoolExp (GBoolExp(..), SessionVarCondition(..), SessionVarOperator(..), ColExp(..))
+import Hasura.Authentication.Session (SessionVariable, unsafeMkSessionVariable)
+import Hasura.RQL.Types.BackendType (BackendType (Postgres), PostgresKind (Vanilla))
+import Hasura.Backends.Postgres.Instances.Schema ()
+import Test.Hspec
+import Test.QuickCheck
+import qualified Data.Vector as Vector
+
+type PG = 'Postgres 'Vanilla
+
+-- Simplified Arbitrary instances for testing
+instance Arbitrary SessionVarOperator where
+  arbitrary = elements [SVOEquals, SVONotEquals, SVOContains, SVOIn]
+
+instance Arbitrary SessionVariable where
+  arbitrary = do
+    name <- elements ["X-Hasura-User-Id", "X-Hasura-Role", "X-Hasura-Permissions"]
+    pure $ unsafeMkSessionVariable (name :: Text)
+
+-- Generate simple JSON values for testing
+genSimpleValue :: Gen Value
+genSimpleValue = oneof
+  [ String <$> arbitrary
+  , Bool <$> arbitrary
+  , Array . Vector.fromList <$> listOf (String <$> arbitrary)
+  ]
+
+instance Arbitrary SessionVarCondition where
+  arbitrary = SessionVarCondition
+    <$> arbitrary
+    <*> arbitrary
+    <*> genSimpleValue
+
+spec :: Spec
+spec = do
+  describe "Session Variable Operators Property Tests" $ do
+    describe "JSON Serialization Properties" $ do
+      it "JSON serialization is reversible" $ property $ \(condition :: SessionVarCondition) ->
+        let boolExp = BoolSessionVar condition :: GBoolExp PG ColExp
+            json = toJSON boolExp
+            result = fromJSON json :: A.Result (GBoolExp PG ColExp)
+        in case result of
+             A.Success parsed -> parsed === boolExp
+             A.Error _ -> property False
+
+    describe "SessionVarCondition Properties" $ do
+      it "Eq instance is reflexive" $ property $ \(condition :: SessionVarCondition) ->
+        condition === condition
+
+      it "Show instance produces non-empty strings" $ property $ \(condition :: SessionVarCondition) ->
+        not (null (show condition))
+
+    describe "SessionVarOperator Properties" $ do
+      it "All operators have distinct string representations" $ 
+        let operators = [SVOEquals, SVONotEquals, SVOContains, SVOIn]
+            shown = map show operators
+        in length shown === length (nub shown)

--- a/server/test-drafts/SessionVarPropertySpec.hs
+++ b/server/test-drafts/SessionVarPropertySpec.hs
@@ -1,10 +1,8 @@
-{-# LANGUAGE StandaloneDeriving #-}
-
 -- | Property-based tests for session variable operators using QuickCheck.
 module Hasura.RQL.IR.BoolExp.SessionVarPropertySpec (spec) where
 
 import Data.Aeson (Value (..), Array, toJSON, fromJSON)
-import Data.Aeson qualified as A
+import Data.Aeson qualified as J
 import Data.List (nub)
 import Data.Text (Text)
 import Hasura.Prelude
@@ -48,10 +46,10 @@ spec = do
       it "JSON serialization is reversible" $ property $ \(condition :: SessionVarCondition) ->
         let boolExp = BoolSessionVar condition :: GBoolExp PG ColExp
             json = toJSON boolExp
-            result = fromJSON json :: A.Result (GBoolExp PG ColExp)
+            result = fromJSON json :: J.Result (GBoolExp PG ColExp)
         in case result of
-             A.Success parsed -> parsed === boolExp
-             A.Error _ -> property False
+             J.Success parsed -> parsed === boolExp
+             J.Error _ -> property False
 
     describe "SessionVarCondition Properties" $ do
       it "Eq instance is reflexive" $ property $ \(condition :: SessionVarCondition) ->

--- a/server/tests-py/test_session_variable_operators.py
+++ b/server/tests-py/test_session_variable_operators.py
@@ -1,0 +1,405 @@
+#!/usr/bin/env python3
+
+"""
+End-to-end tests for session variable operators in Hasura GraphQL Engine.
+
+These tests verify that the new session variable operators (_seq, _sne, _scontains, _sin)
+work correctly in real permission scenarios.
+"""
+
+import pytest
+import json
+from validate import check_query_f
+
+
+class TestSessionVariableOperators:
+    """Test session variable operators in permissions."""
+
+    @classmethod
+    def dir(cls):
+        return 'queries/session_variable_operators'
+
+    def test_seq_operator_user_isolation(self, hge_ctx):
+        """Test _seq operator for user isolation patterns."""
+        # Set up table and permissions using _seq
+        check_query_f(hge_ctx, self.dir() + '/setup_user_table.yaml')
+        
+        # Create permission that only allows users to see their own records
+        permission_metadata = {
+            "type": "create_select_permission",
+            "args": {
+                "table": "users",
+                "role": "user",
+                "permission": {
+                    "columns": ["id", "name", "email"],
+                    "filter": {
+                        "_seq": {
+                            "var": "X-Hasura-User-Id",
+                            "value": "123"
+                        }
+                    }
+                }
+            }
+        }
+        
+        # Apply permission
+        resp = hge_ctx.v1q(permission_metadata)
+        assert resp['message'] == 'success'
+        
+        # Test query with matching session variable
+        headers = {'X-Hasura-Role': 'user', 'X-Hasura-User-Id': '123'}
+        query = {
+            "query": "{ users { id name email } }"
+        }
+        
+        resp = hge_ctx.v1graphql(query, headers=headers)
+        assert 'errors' not in resp
+        # Should return results since session variable matches
+        
+        # Test query with non-matching session variable
+        headers = {'X-Hasura-Role': 'user', 'X-Hasura-User-Id': '456'}
+        resp = hge_ctx.v1graphql(query, headers=headers)
+        assert 'errors' not in resp
+        # Should return empty results since session variable doesn't match
+        assert resp['data']['users'] == []
+        
+        # Cleanup
+        check_query_f(hge_ctx, self.dir() + '/teardown_user_table.yaml')
+
+    def test_sne_operator_role_exclusion(self, hge_ctx):
+        """Test _sne operator for role exclusion patterns."""
+        check_query_f(hge_ctx, self.dir() + '/setup_articles_table.yaml')
+        
+        # Create permission that excludes guest users
+        permission_metadata = {
+            "type": "create_select_permission",
+            "args": {
+                "table": "articles",
+                "role": "public",
+                "permission": {
+                    "columns": ["id", "title", "content"],
+                    "filter": {
+                        "_sne": {
+                            "var": "X-Hasura-Role",
+                            "value": "guest"
+                        }
+                    }
+                }
+            }
+        }
+        
+        resp = hge_ctx.v1q(permission_metadata)
+        assert resp['message'] == 'success'
+        
+        # Test with non-guest role (should work)
+        headers = {'X-Hasura-Role': 'public'}
+        query = {"query": "{ articles { id title } }"}
+        resp = hge_ctx.v1graphql(query, headers=headers)
+        assert 'errors' not in resp
+        
+        # Cleanup
+        check_query_f(hge_ctx, self.dir() + '/teardown_articles_table.yaml')
+
+    def test_scontains_operator_permission_check(self, hge_ctx):
+        """Test _scontains operator for permission-based access."""
+        check_query_f(hge_ctx, self.dir() + '/setup_projects_table.yaml')
+        
+        # Create permission that checks for specific permission in session
+        permission_metadata = {
+            "type": "create_select_permission",
+            "args": {
+                "table": "projects",
+                "role": "user",
+                "permission": {
+                    "columns": ["id", "name", "description"],
+                    "filter": {
+                        "_scontains": {
+                            "var": "X-Hasura-Permissions",
+                            "value": "view:projects"
+                        }
+                    }
+                }
+            }
+        }
+        
+        resp = hge_ctx.v1q(permission_metadata)
+        assert resp['message'] == 'success'
+        
+        # Test with matching permission
+        headers = {
+            'X-Hasura-Role': 'user',
+            'X-Hasura-Permissions': 'view:projects,edit:tasks'
+        }
+        query = {"query": "{ projects { id name } }"}
+        resp = hge_ctx.v1graphql(query, headers=headers)
+        assert 'errors' not in resp
+        
+        # Test with non-matching permission
+        headers = {
+            'X-Hasura-Role': 'user',
+            'X-Hasura-Permissions': 'edit:tasks,view:users'
+        }
+        resp = hge_ctx.v1graphql(query, headers=headers)
+        assert 'errors' not in resp
+        assert resp['data']['projects'] == []
+        
+        # Cleanup
+        check_query_f(hge_ctx, self.dir() + '/teardown_projects_table.yaml')
+
+    def test_sin_operator_group_membership(self, hge_ctx):
+        """Test _sin operator for group membership patterns."""
+        check_query_f(hge_ctx, self.dir() + '/setup_documents_table.yaml')
+        
+        # Create permission that checks group membership
+        permission_metadata = {
+            "type": "create_select_permission",
+            "args": {
+                "table": "documents",
+                "role": "user",
+                "permission": {
+                    "columns": ["id", "title", "content"],
+                    "filter": {
+                        "_sin": {
+                            "var": "X-Hasura-Group",
+                            "value": ["admin", "editor", "viewer"]
+                        }
+                    }
+                }
+            }
+        }
+        
+        resp = hge_ctx.v1q(permission_metadata)
+        assert resp['message'] == 'success'
+        
+        # Test with allowed group
+        headers = {'X-Hasura-Role': 'user', 'X-Hasura-Group': 'editor'}
+        query = {"query": "{ documents { id title } }"}
+        resp = hge_ctx.v1graphql(query, headers=headers)
+        assert 'errors' not in resp
+        
+        # Test with disallowed group
+        headers = {'X-Hasura-Role': 'user', 'X-Hasura-Group': 'guest'}
+        resp = hge_ctx.v1graphql(query, headers=headers)
+        assert 'errors' not in resp
+        assert resp['data']['documents'] == []
+        
+        # Cleanup
+        check_query_f(hge_ctx, self.dir() + '/teardown_documents_table.yaml')
+
+    def test_complex_permission_combinations(self, hge_ctx):
+        """Test complex combinations of session variable operators."""
+        check_query_f(hge_ctx, self.dir() + '/setup_complex_table.yaml')
+        
+        # Create permission with multiple session variable conditions
+        permission_metadata = {
+            "type": "create_select_permission",
+            "args": {
+                "table": "sensitive_data",
+                "role": "user",
+                "permission": {
+                    "columns": ["id", "data"],
+                    "filter": {
+                        "_and": [
+                            {
+                                "_sne": {
+                                    "var": "X-Hasura-Role",
+                                    "value": "guest"
+                                }
+                            },
+                            {
+                                "_or": [
+                                    {
+                                        "_seq": {
+                                            "var": "X-Hasura-Role",
+                                            "value": "admin"
+                                        }
+                                    },
+                                    {
+                                        "_scontains": {
+                                            "var": "X-Hasura-Permissions",
+                                            "value": "view:sensitive"
+                                        }
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                }
+            }
+        }
+        
+        resp = hge_ctx.v1q(permission_metadata)
+        assert resp['message'] == 'success'
+        
+        # Test admin access
+        headers = {'X-Hasura-Role': 'user', 'X-Hasura-Role': 'admin'}
+        query = {"query": "{ sensitive_data { id } }"}
+        resp = hge_ctx.v1graphql(query, headers=headers)
+        assert 'errors' not in resp
+        
+        # Test permission-based access
+        headers = {
+            'X-Hasura-Role': 'user',
+            'X-Hasura-Permissions': 'view:sensitive,edit:data'
+        }
+        resp = hge_ctx.v1graphql(query, headers=headers)
+        assert 'errors' not in resp
+        
+        # Test denied access (guest role)
+        headers = {'X-Hasura-Role': 'guest'}
+        resp = hge_ctx.v1graphql(query, headers=headers)
+        assert 'errors' not in resp
+        assert resp['data']['sensitive_data'] == []
+        
+        # Cleanup
+        check_query_f(hge_ctx, self.dir() + '/teardown_complex_table.yaml')
+
+    def test_explain_query_with_session_variables(self, hge_ctx):
+        """Test that EXPLAIN queries work correctly with session variable operators."""
+        check_query_f(hge_ctx, self.dir() + '/setup_explain_table.yaml')
+        
+        # Create permission with session variable operator
+        permission_metadata = {
+            "type": "create_select_permission",
+            "args": {
+                "table": "test_table",
+                "role": "user",
+                "permission": {
+                    "columns": ["id", "name"],
+                    "filter": {
+                        "_seq": {
+                            "var": "X-Hasura-User-Id",
+                            "value": "123"
+                        }
+                    }
+                }
+            }
+        }
+        
+        resp = hge_ctx.v1q(permission_metadata)
+        assert resp['message'] == 'success'
+        
+        # Test EXPLAIN query
+        explain_query = {
+            "type": "explain",
+            "args": {
+                "query": "query { test_table { id name } }",
+                "user": {
+                    "X-Hasura-Role": "user",
+                    "X-Hasura-User-Id": "123"
+                }
+            }
+        }
+        
+        resp = hge_ctx.v1q(explain_query)
+        assert 'sql' in resp
+        assert 'plan' in resp
+        # Verify that the session variable condition is resolved in the SQL
+        
+        # Cleanup
+        check_query_f(hge_ctx, self.dir() + '/teardown_explain_table.yaml')
+
+    def test_session_variable_operators_in_mutations(self, hge_ctx):
+        """Test session variable operators in mutation permissions."""
+        check_query_f(hge_ctx, self.dir() + '/setup_mutation_table.yaml')
+        
+        # Create insert permission with session variable check
+        permission_metadata = {
+            "type": "create_insert_permission",
+            "args": {
+                "table": "user_posts",
+                "role": "user",
+                "permission": {
+                    "check": {
+                        "_seq": {
+                            "var": "X-Hasura-User-Id",
+                            "value": "author_id"  # Check against column value
+                        }
+                    },
+                    "columns": ["title", "content", "author_id"]
+                }
+            }
+        }
+        
+        resp = hge_ctx.v1q(permission_metadata)
+        assert resp['message'] == 'success'
+        
+        # Test mutation with valid session variable
+        headers = {'X-Hasura-Role': 'user', 'X-Hasura-User-Id': '123'}
+        mutation = {
+            "query": '''
+                mutation {
+                    insert_user_posts_one(object: {title: "Test", content: "Content", author_id: "123"}) {
+                        id
+                        title
+                    }
+                }
+            '''
+        }
+        
+        resp = hge_ctx.v1graphql(mutation, headers=headers)
+        assert 'errors' not in resp
+        
+        # Cleanup
+        check_query_f(hge_ctx, self.dir() + '/teardown_mutation_table.yaml')
+
+    def test_error_handling_missing_session_variables(self, hge_ctx):
+        """Test graceful handling when required session variables are missing."""
+        check_query_f(hge_ctx, self.dir() + '/setup_error_table.yaml')
+        
+        # Create permission requiring session variable
+        permission_metadata = {
+            "type": "create_select_permission",
+            "args": {
+                "table": "protected_table",
+                "role": "user",
+                "permission": {
+                    "columns": ["id", "data"],
+                    "filter": {
+                        "_seq": {
+                            "var": "X-Hasura-Required-Var",
+                            "value": "expected"
+                        }
+                    }
+                }
+            }
+        }
+        
+        resp = hge_ctx.v1q(permission_metadata)
+        assert resp['message'] == 'success'
+        
+        # Test query without required session variable
+        headers = {'X-Hasura-Role': 'user'}  # Missing X-Hasura-Required-Var
+        query = {"query": "{ protected_table { id } }"}
+        resp = hge_ctx.v1graphql(query, headers=headers)
+        
+        # Should not error, but should return empty results
+        assert 'errors' not in resp
+        assert resp['data']['protected_table'] == []
+        
+        # Cleanup
+        check_query_f(hge_ctx, self.dir() + '/teardown_error_table.yaml')
+
+
+# Helper test configurations
+setup_queries = [
+    'setup_user_table.yaml',
+    'setup_articles_table.yaml', 
+    'setup_projects_table.yaml',
+    'setup_documents_table.yaml',
+    'setup_complex_table.yaml',
+    'setup_explain_table.yaml',
+    'setup_mutation_table.yaml',
+    'setup_error_table.yaml'
+]
+
+teardown_queries = [
+    'teardown_user_table.yaml',
+    'teardown_articles_table.yaml',
+    'teardown_projects_table.yaml', 
+    'teardown_documents_table.yaml',
+    'teardown_complex_table.yaml',
+    'teardown_explain_table.yaml',
+    'teardown_mutation_table.yaml',
+    'teardown_error_table.yaml'
+]


### PR DESCRIPTION
<!-- Thank you for submitting this PR! :) -->
<!-- Provide a general summary of your changes in the Title above ^, end with (close #<issue-no>) or (fix #<issue-no>) -->

### Description
This adds new operators for comparing session values with constants so that you can directly compare values in them rather than only comparing with a database entity.

<img width="1904" height="944" alt="Screenshot 2025-08-16 at 8 17 30 PM" src="https://github.com/user-attachments/assets/35342644-c1b1-4801-ab28-82b487adec1c" />

https://github.com/user-attachments/assets/d548f11b-7793-45e1-ad6d-2e690e068cfe



They are prepended with `s` (for session) but work the same way as the regular boolean operators:
- `_seq` (Session Equals)
  - Purpose: Checks if a session variable exactly equals a specific value
  - Use case: User isolation - "only show records where user_id matches the logged-in user"
  - Example: {"_seq": {"var": "X-Hasura-User-Id", "value": "123"}}

- ` _sne` (Session Not Equals)
  - Purpose: Checks if a session variable does NOT equal a specific value
  - Use case: Role exclusion - "show data to everyone except guests"
  - Example: {"_sne": {"var": "X-Hasura-Role", "value": "guest"}}

- `_scontains` (Session Contains)
  - Purpose: Checks if a value is contained within a session variable array
  - Use case: Group/permission membership - "user belongs to a specific group from their session groups list"
  - Session variable format: JSON array (e.g., ["admin", "editor", "viewer"])
  - Example: {"_scontains": {"var": "X-Hasura-Groups", "value": "admin"}}
    - Checks if "admin" is in the session variable array ["admin", "editor", "viewer"]
    - Returns true if the value exists in the session array, false otherwise

- ` _sin` (Session In List)
  - Purpose: Checks if a session variable value is in a list of allowed values
  - Use case: Group membership - "user belongs to admin, editor, or viewer groups"
  - Example: {"_sin": {"var": "X-Hasura-Group", "value": ["admin", "editor", "viewer"]}}

### Changelog

<!-- Fill this section if this is a user facing change. -->

__Component__ : server / console <!-- choose one -->

__Type__: enhancement <!-- choose one -->

__Product__: community-edition

#### Short Changelog

Add operators for LHS comparison with session variables

#### Long Changelog

<!--
  Detailed description of this change. This might contain links to documentation, blogposts, images. Use markdown for formatting.
  (optional if you choose to fill the Short Changelog section instead)
-->


<!-- Changelog Section End -->

### Related Issues
<!-- Please make sure you have an issue associated with this Pull Request -->
<!-- And then add `(close #<issue-no>)` to the pull request title -->
<!-- Add the issue number below (e.g. #234) -->

### Solution and Design
<!-- How is this issue solved/fixed? What is the design? -->
<!-- It's better if we elaborate -->

### Steps to test and verify
<!-- If this is a feature, what are the steps to try them out? -->
<!-- If this is a bug-fix, how do we verify the fix? -->

### Limitations, known bugs & workarounds
<!-- Limitations of the PR, known bugs and suggested workarounds -->
<!-- Feel free to delete these comment lines -->

### Server checklist
<!-- A checklist for server code -->

#### Catalog upgrade
<!-- Is hdb_catalog version bumped? -->
Does this PR change Hasura Catalog version?
- [x] No
- [ ] Yes
  - [ ] Updated docs with SQL for downgrading the catalog <!-- https://hasura.io/docs/latest/graphql/core/deployment/downgrading.html#downgrading-across-catalogue-versions -->

#### Metadata
<!-- Hasura metadata changes -->

Does this PR add a new Metadata feature?
- [ ] No
- [x] Yes
  - Does `run_sql` auto manages the new metadata through schema diffing?
    - [ ] Yes
    - [x] Not required
  - Does `run_sql` auto manages the definitions of metadata on renaming?
    - [ ] Yes
    - [x] Not required
  - Does `export_metadata`/`replace_metadata` supports the new metadata added?
    - [ ] Yes
    - [x] Not required


#### GraphQL
- [x] No new GraphQL schema is generated
- [ ] New GraphQL schema is being generated:
   - [ ] New types and typenames are correlated
   <!-- No dangling types or typenames with missing types (a potential bug, introspection fails) -->
   <!-- If you have anything in your mind, which can be added here as a check list item, please submit a PR to update this template :) -->

#### Breaking changes

- [x] No Breaking changes
- [ ] There are breaking changes:

  1. Metadata API

     Existing `query` types:
     - [ ] Modify `args` payload which is not backward compatible
     - [ ] Behavioural change of the API
     - [ ] Change in response `JSON` schema
     - [ ] Change in error code
     <!-- Add if anything not listed above -->

  2. GraphQL API

     Schema Generation:
     <!-- Any changes in schema auto-generation logic -->
     <!-- All GraphQL schema names are case sensitive -->
     - [ ] Change in any `NamedType`
     - [ ] Change in table field names
     <!-- Add if anything not listed above -->

     Schema Resolve:-
     <!-- Any change in logic of resolving input request -->
     - [ ] Change in treatment of `null` value for any input fields <!-- Explain them below -->
     <!-- Add if anything not listed above -->

  3. Logging

     - [ ] Log `JSON` schema has changed
     - [ ] Log `type` names have changed
     <!-- Add if anything not listed above -->

<!-- Add any other breaking change not mentioned above -->

<!-- Explain briefly about your breaking changes below -->
